### PR TITLE
fix: show file names for grep command on Linux

### DIFF
--- a/src/fuzzy_finder/fuzzy_finder.rs
+++ b/src/fuzzy_finder/fuzzy_finder.rs
@@ -30,7 +30,10 @@ pub fn run(makefile: Makefile) {
     }
 }
 
-fn get_preview_command(file_paths: Vec<String>) -> String {
+fn get_preview_command(mut file_paths: Vec<String>) -> String {
+    // workaround for https://stackoverflow.com/questions/15432156/display-filename-before-matching-line
+    // For more information, see https://github.com/kyu08/fzf-make/issues/53#issuecomment-1684872018
+    file_paths.push(String::from("/dev/null"));
     // MEMO: result has format like `test.mk:2:echo-mk`
     let preview_command = format!(
         r#"


### PR DESCRIPTION
fixes #53
