### PR TITLE
Build when brew install executed

### DIFF
--- a/.github/workflows/brew-release.yml
+++ b/.github/workflows/brew-release.yml
@@ -18,7 +18,6 @@ jobs:
           formula-path: Formula/fzf-make.rb
           homebrew-tap: kyu08/homebrew-tap
           base-branch: main
-          download-url: https://github.com/kyu08/fzf-make/releases/download/${{ steps.extract-version.outputs.tag-name }}/fzf-make
           commit-message: |
             {{formulaName}} {{version}}
 


### PR DESCRIPTION
This PR makes `url` of formula to format like `https://github.com/OWNER/REPO/archive/refs/tags/<tag-name>.tar.gz`.
```md
download-url: the package download URL for the Homebrew formula.

Defaults to https://github.com/OWNER/REPO/archive/refs/tags/<tag-name>.tar.gz, where OWNER/REPO is the repository that is running the Actions workflow.
```
https://github.com/mislav/bump-homebrew-formula-action