### PR TITLE
Improve the flake decalaration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,10 +7,11 @@
   };
 
   outputs = { nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
-      cargoTOML = builtins.fromTOML (builtins.readFile ./Cargo.toml);
-        in
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        cargoTOML = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+      in
       rec
       {
         devShell = pkgs.mkShell {
@@ -39,5 +40,5 @@
           };
           default = fzf-make;
         };
-    });
+      });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -9,17 +9,15 @@
   outputs = { nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = nixpkgs.legacyPackages.${system};
-      cargoTOML = builtins.fromTOML (builtins.readFile (./. + "/Cargo.toml"));
+      cargoTOML = builtins.fromTOML (builtins.readFile ./Cargo.toml);
         in
+      rec
       {
-        devShells.default = pkgs.mkShell {
-          packages = with pkgs; [
-            bat
-            cargo
-            gnumake
-          ];
+        devShell = pkgs.mkShell {
+          inputsFrom = [ packages.fzf-make ];
         };
 
+        formatter = pkgs.nixpkgs-fmt;
         packages = rec {
           fzf-make = pkgs.rustPlatform.buildRustPackage {
             pname = "fzf-make";
@@ -27,8 +25,17 @@
 
             src = ./.;
             cargoLock.lockFile = ./Cargo.lock;
-          
-            buildInputs = [ pkgs.bat ];
+
+            nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
+            postInstall =
+              let
+                runtimeDeps = with pkgs; [ bat gnugrep gnumake ];
+              in
+              ''
+                wrapProgram $out/bin/fzf-make \
+                  --set SHELL ${pkgs.runtimeShell} \
+                  --suffix PATH : ${pkgs.lib.makeBinPath runtimeDeps}
+              '';
           };
           default = fzf-make;
         };


### PR DESCRIPTION
Bring minor improvement the the `flake.nix`:
- Use `devShell` (singular) attribute instead of `devShells` (list)
- Resolve dev shell dependencies from the `fzf-make` package inputs.
- Added nixpkgs-fmt to ensure a proper flake formatting
- Use direct path from `Cargo.toml`
- Update package declaration to reflect nixpkgs