### PR TITLE
fix: devShells default output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       in
       rec
       {
-        devShell = pkgs.mkShell {
+        devShells.default = pkgs.mkShell {
           inputsFrom = [ packages.fzf-make ];
         };
 


### PR DESCRIPTION
The flake output `devShell` has been deprecated in favor of `devShells` for 2 years now:
https://nixos.org/manual/nix/stable/release-notes/rl-2.7.html?highlight=devShell#release-27-2022-03-07

Nix itself already warns about this, and it is feasible that at some point the backwards compatibility will be dropped.
