### PR TITLE
Add define block skip

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
       {
         devShells.default = pkgs.mkShell {
           inputsFrom = [ packages.fzf-make ];
-          packages = with pkgs; [ clippy typos ];
+          packages = with pkgs; [ rustfmt clippy typos ];
         };
 
         formatter = pkgs.nixpkgs-fmt;

--- a/src/model/target.rs
+++ b/src/model/target.rs
@@ -4,32 +4,6 @@ use regex::Regex;
 
 use super::file_util;
 
-const DEFINE_BLOCK_START: &str = "define";
-const DEFINE_BLOCK_END: &str = "endef";
-const OVERRIDE: &str = "override";
-
-enum LineType { Normal, DefineStart, DefineEnd }
-
-fn get_line_type(line: &str) -> LineType {
-    let words: Vec<&str> = line.split_whitespace().collect();
-
-    if words.is_empty() {
-        return LineType::Normal;
-    }
-
-    if words.len() >= 2
-        && words[0] == OVERRIDE
-        && words[1] == DEFINE_BLOCK_START {
-        return LineType::DefineStart;
-    }
-
-    match words[0] {
-        DEFINE_BLOCK_START => LineType::DefineStart,
-        DEFINE_BLOCK_END => LineType::DefineEnd,
-        _ => LineType::Normal,
-    }
-}
-
 #[derive(Debug, Clone, PartialEq)]
 pub struct Targets(pub Vec<String>);
 
@@ -53,6 +27,32 @@ impl Targets {
         }
 
         Targets(result)
+    }
+}
+
+const DEFINE_BLOCK_START: &str = "define";
+const DEFINE_BLOCK_END: &str = "endef";
+const OVERRIDE: &str = "override";
+
+enum LineType { Normal, DefineStart, DefineEnd }
+
+fn get_line_type(line: &str) -> LineType {
+    let words: Vec<&str> = line.split_whitespace().collect();
+
+    if words.is_empty() {
+        return LineType::Normal;
+    }
+
+    if words.len() >= 2
+        && words[0] == OVERRIDE
+        && words[1] == DEFINE_BLOCK_START {
+        return LineType::DefineStart;
+    }
+
+    match words[0] {
+        DEFINE_BLOCK_START => LineType::DefineStart,
+        DEFINE_BLOCK_END => LineType::DefineEnd,
+        _ => LineType::Normal,
     }
 }
 

--- a/src/model/target.rs
+++ b/src/model/target.rs
@@ -4,24 +4,27 @@ use regex::Regex;
 
 use super::file_util;
 
+const START_OF_DEFINE_BLOCK: &str = "define";
+const END_OF_DEFINE_BLOCK: &str = "endef";
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Targets(pub Vec<String>);
 
 impl Targets {
     pub fn new(content: String) -> Targets {
         let mut result: Vec<String> = Vec::new();
-        let mut in_define_block = false;
+        let mut ignored_block_count = 0;
 
         for line in content.lines() {
-            if in_define_block {
-                if line.trim().starts_with("endef") {
-                    in_define_block = false;
-                }
+            if line.trim() == START_OF_DEFINE_BLOCK {
+                ignored_block_count += 1;
                 continue;
             }
+            if line.trim() == END_OF_DEFINE_BLOCK {
+                ignored_block_count -= 1;
+            }
 
-            if line.trim().starts_with("define") {
-                in_define_block = true;
+            if 0 < ignored_block_count {
                 continue;
             }
 

--- a/src/model/target.rs
+++ b/src/model/target.rs
@@ -10,7 +10,21 @@ pub struct Targets(pub Vec<String>);
 impl Targets {
     pub fn new(content: String) -> Targets {
         let mut result: Vec<String> = Vec::new();
+        let mut in_define_block = false;
+
         for line in content.lines() {
+            if in_define_block {
+                if line.trim().starts_with("endef") {
+                    in_define_block = false;
+                }
+                continue;
+            }
+
+            if line.trim().starts_with("define") {
+                in_define_block = true;
+                continue;
+            }
+
             if let Some(t) = line_to_target(line.to_string()) {
                 result.push(t);
             }
@@ -25,6 +39,7 @@ pub fn target_line_number(path: PathBuf, target_to_search: String) -> Option<u32
         Ok(c) => c,
         Err(_) => return None,
     };
+
     for (index, line) in content.lines().enumerate() {
         if let Some(t) = line_to_target(line.to_string()) {
             if t == target_to_search {

--- a/src/model/target.rs
+++ b/src/model/target.rs
@@ -14,8 +14,12 @@ impl Targets {
 
         for line in content.lines() {
             match get_line_type(line) {
-                LineType::DefineStart => { define_block_depth += 1; }
-                LineType::DefineEnd => { define_block_depth -= 1; }
+                LineType::DefineStart => {
+                    define_block_depth += 1;
+                }
+                LineType::DefineEnd => {
+                    define_block_depth -= 1;
+                }
                 LineType::Normal => {
                     if define_block_depth == 0 {
                         if let Some(t) = line_to_target(line.to_string()) {
@@ -34,7 +38,11 @@ const DEFINE_BLOCK_START: &str = "define";
 const DEFINE_BLOCK_END: &str = "endef";
 const OVERRIDE: &str = "override";
 
-enum LineType { Normal, DefineStart, DefineEnd }
+enum LineType {
+    Normal,
+    DefineStart,
+    DefineEnd,
+}
 
 fn get_line_type(line: &str) -> LineType {
     let words: Vec<&str> = line.split_whitespace().collect();
@@ -43,9 +51,7 @@ fn get_line_type(line: &str) -> LineType {
         return LineType::Normal;
     }
 
-    if words.len() >= 2
-        && words[0] == OVERRIDE
-        && words[1] == DEFINE_BLOCK_START {
+    if words.len() >= 2 && words[0] == OVERRIDE && words[1] == DEFINE_BLOCK_START {
         return LineType::DefineStart;
     }
 
@@ -185,7 +191,7 @@ not-good:
 endef
                 ",
                 expect: Targets(vec![]),
-            }
+            },
         ];
 
         for case in cases {

--- a/src/model/target.rs
+++ b/src/model/target.rs
@@ -49,10 +49,13 @@ fn get_line_type(line: &str) -> LineType {
         return LineType::DefineStart;
     }
 
-    match words[0] {
-        DEFINE_BLOCK_START => LineType::DefineStart,
-        DEFINE_BLOCK_END => LineType::DefineEnd,
-        _ => LineType::Normal,
+    match words.first() {
+        Some(&w) => match w {
+            DEFINE_BLOCK_START => LineType::DefineStart,
+            DEFINE_BLOCK_END => LineType::DefineEnd,
+            _ => LineType::Normal,
+        },
+        None => LineType::Normal,
     }
 }
 


### PR DESCRIPTION
Hi, I tried to implement the `define` block skip myself, as it is a feature that I would like to have.

- Resolves #236
> *Tested on glibc's Makefile, and seems skip define properly.*

> [!NOTE]
> *With some background in C, I'm still unfamiliar with Rust, so I focused on a simple implementation that works. It might not be fancy, and not be the best way to pull this off, so I rely on your expertise for some feedback.*