### PR TITLE
A row including 🛠️ is shifted in alacritty #266

### DIFF
--- a/src/usecase/fzf_make/ui.rs
+++ b/src/usecase/fzf_make/ui.rs
@@ -155,7 +155,7 @@ fn preview_command(file_name: String, line_number: u32) -> CommandBuilder {
 fn render_targets_block(model: &mut Model, f: &mut Frame, chunk: ratatui::layout::Rect) {
     f.render_stateful_widget(
         targets_block(
-            " 🛠️  Targets ",
+            " 📢 Targets ",
             model.narrow_down_targets(),
             model.current_pane.is_main(),
         ),


### PR DESCRIPTION
Resolves #266 

|Before|<img width="1504" alt="image" src="https://github.com/kyu08/fzf-make/assets/49891479/57f9630d-33ae-4ed5-a153-ae1823c90a98">|
|---|---|
|After|<img width="1500" alt="image" src="https://github.com/kyu08/fzf-make/assets/49891479/7d3eee69-7622-4dfc-b5b6-d05ebc7193c9">|

