### PR TITLE
chore(ci): fix lint error to use `unwrap_or_default()`

### DIFF
--- a/src/usecase/fzf_make/ui.rs
+++ b/src/usecase/fzf_make/ui.rs
@@ -193,13 +193,12 @@ fn render_history_block(
     f: &mut Frame,
     chunk: ratatui::layout::Rect,
 ) {
-    let h = match model.get_history() {
-        Some(h) => h,
-        None => vec![],
-    };
-
     f.render_stateful_widget(
-        targets_block(" 📚 History ", h, model.current_pane.is_history()),
+        targets_block(
+            " 📚 History ",
+            model.get_history().unwrap_or_default(),
+            model.current_pane.is_history(),
+        ),
         chunk,
         // NOTE: It is against TEA's way to update the model value on the UI side, but it is unavoidable so it is allowed.
         &mut model.histories_list_state,


### PR DESCRIPTION
Fixed this error from clippy.
```shell
error: match can be simplified with `.unwrap_or_default()`
   --> src/usecase/fzf_make/ui.rs:196:13
    |
[196](https://github.com/kyu08/fzf-make/actions/runs/9626356023/job/26552236621#step:3:197) |       let h = match model.get_history() {
    |  _____________^
[197](https://github.com/kyu08/fzf-make/actions/runs/9626356023/job/26552236621#step:3:198) | |         Some(h) => h,
198 | |         None => vec![],
[199](https://github.com/kyu08/fzf-make/actions/runs/9626356023/job/26552236621#step:3:200) | |     };
    | |_____^ help: replace it with: `model.get_history().unwrap_or_default()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_unwrap_or_default
    = note: `-D clippy::manual-unwrap-or-default` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_unwrap_or_default)]`
```