### PR TITLE
fix(lint): fix lint error `error: match can be simplified with .unwrap_or_default()` #312

### DIFF
--- a/src/usecase/fzf_make/app.rs
+++ b/src/usecase/fzf_make/app.rs
@@ -86,11 +86,8 @@ impl Model<'_> {
                     Err(_) => return Histories::new(makefile_path, vec![]), // NOTE: Show error message on message pane https://github.com/kyu08/fzf-make/issues/152
                     Ok(c) => c,
                 };
-            let histories = toml::parse_history(content.to_string()).unwrap_or_else(|err| {
-                // Show error message on message pane
-                eprintln!("Error parsing history: {}", err); // NOTE: Show error message on message pane https://github.com/kyu08/fzf-make/issues/152
-                vec![]
-            });
+            // TODO: Show error message on message pane if parsing history file failed. https://github.com/kyu08/fzf-make/issues/152
+            let histories = toml::parse_history(content.to_string()).unwrap_or_default();
 
             Histories::new(makefile_path, histories)
         })

--- a/src/usecase/fzf_make/app.rs
+++ b/src/usecase/fzf_make/app.rs
@@ -86,10 +86,11 @@ impl Model<'_> {
                     Err(_) => return Histories::new(makefile_path, vec![]), // NOTE: Show error message on message pane https://github.com/kyu08/fzf-make/issues/152
                     Ok(c) => c,
                 };
-            let histories = match toml::parse_history(content.to_string()) {
-                Err(_) => vec![], // NOTE: Show error message on message pane https://github.com/kyu08/fzf-make/issues/152
-                Ok(h) => h,
-            };
+            let histories = toml::parse_history(content.to_string()).unwrap_or_else(|err| {
+                // Show error message on message pane
+                eprintln!("Error parsing history: {}", err); // NOTE: Show error message on message pane https://github.com/kyu08/fzf-make/issues/152
+                vec![]
+            });
 
             Histories::new(makefile_path, histories)
         })


### PR DESCRIPTION
Resolves Issue https://github.com/kyu08/fzf-make/issues/312