### PR TITLE
update(history): update history file format to handler multiple task runner like pnpm, yarn, e.t.c. #315

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -1093,3 +1093,30 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+================================================================
+
+rust-pretty-assertions
+https://github.com/rust-pretty-assertions/rust-pretty-assertions/tree/main
+----------------------------------------------------------------
+
+The MIT License (MIT)
+
+Copyright (c) 2016 rust-derive-builder contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +192,7 @@ dependencies = [
  "crossterm",
  "fuzzy-matcher",
  "portable-pty",
+ "pretty_assertions",
  "ratatui",
  "regex",
  "serde",
@@ -431,6 +438,16 @@ dependencies = [
  "shell-words",
  "winapi",
  "winreg",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -1077,6 +1094,12 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ tui-textarea = "0.6.0"
 toml = "0.8.19"
 serde = {version = "1.0.204", features = ["derive"]}
 simple-home-dir = "0.4.0"
+pretty_assertions = "1.4.1"

--- a/src/controller/controller_main.rs
+++ b/src/controller/controller_main.rs
@@ -1,9 +1,8 @@
+use crate::usecase::fzf_make::FzfMake;
+use crate::usecase::{fzf_make, help, history, invalid_arg, repeat, usecase_main, version};
 use colored::Colorize;
 use std::sync::Arc;
 use std::{collections::HashMap, env};
-
-use crate::usecase::fzf_make::FzfMake;
-use crate::usecase::{fzf_make, help, history, invalid_arg, repeat, usecase_main, version};
 
 pub fn run() {
     let command_line_args = env::args().collect();

--- a/src/file/toml.rs
+++ b/src/file/toml.rs
@@ -81,13 +81,31 @@ mod test {
             Case {
                 title: "Success",
                 content: r#"
-[[history]]
+[[tasks]]
 path = "/Users/user/code/fzf-make"
-executed-targets = ["test", "check", "spell-check"]
 
-[[history]]
+[[tasks.commands]]
+runner = "make"
+command = "test"
+
+[[tasks.commands]]
+runner = "make"
+command = "check"
+
+[[tasks.commands]]
+runner = "make"
+command = "spell-check"
+
+[[tasks]]]
 path = "/Users/user/code/golang/go-playground"
-executed-targets = ["run", "echo1"]
+
+[[tasks.commands]]
+runner = "make"
+command = "run"
+
+[[tasks.commands]]
+runner = "make"
+command = "echo1"
                 "#
                 .to_string(),
                 expect: Ok(vec![
@@ -96,7 +114,9 @@ executed-targets = ["run", "echo1"]
                         vec![
                             command::Command::new(
                                 runner_type::RunnerType::Make,
-                                "target-a".to_string(),
+                                // WARN: ここにコマンドファイル名って持つ必要ないんだっけ？
+                                // ないならいらないフィールドをoptionにするか構造体を分けるかしたいなー
+                                "test".to_string(),
                                 PathBuf::from("Makefile"),
                                 1,
                             ),

--- a/src/file/toml.rs
+++ b/src/file/toml.rs
@@ -33,13 +33,13 @@ impl Histories {
         }
     }
 
-    // fn from(histories: histories::Histories) -> Self {
-    //     let mut result: Vec<History> = vec![];
-    //     for h in histories.histories {
-    //         result.push(History::from(h));
-    //     }
-    //     Self { histories: result }
-    // }
+    fn from(histories: histories::Histories) -> Self {
+        let mut result: Vec<History> = vec![];
+        for h in histories.histories {
+            result.push(History::from(h));
+        }
+        Self { histories: result }
+    }
 
     pub fn into(self) -> histories::Histories {
         let mut result: Vec<histories::History> = vec![];
@@ -118,27 +118,19 @@ pub fn parse_history(content: String) -> Result<Histories> {
 }
 
 pub fn store_history(
-    current_working_directory: PathBuf,
     history_directory_path: PathBuf,
     history_file_name: String,
-    new_history: histories::History,
+    new_history: histories::Histories,
 ) -> Result<()> {
-    let mut all_histories = Histories::get_history();
-
-    for (i, history) in all_histories.clone().histories.iter().enumerate() {
-        if history.path == current_working_directory {
-            all_histories.histories[i] = History::from(new_history.clone());
-        }
-    }
-
-    // TODO: 2. cwdの履歴を更新する
-
     if !history_directory_path.is_dir() {
         fs::create_dir_all(history_directory_path.clone())?;
     }
-    // TODO: 3. historiesを保存する
     let mut history_file = File::create(history_directory_path.join(history_file_name))?;
-    history_file.write_all(toml::to_string(&all_histories).unwrap().as_bytes())?;
+    history_file.write_all(
+        toml::to_string(&Histories::from(new_history))
+            .unwrap()
+            .as_bytes(),
+    )?;
     history_file.flush()?;
 
     Ok(())

--- a/src/file/toml.rs
+++ b/src/file/toml.rs
@@ -1,11 +1,13 @@
 use super::path_to_content;
 use crate::model::{
-    histories::{self, history_file_path},
+    histories::{self},
     runner_type,
 };
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use simple_home_dir::home_dir;
 use std::{
+    env,
     fs::{self, File},
     io::Write,
     path::PathBuf,
@@ -109,6 +111,28 @@ impl HistoryCommand {
             runner_type: self.runner_type,
             name: self.name,
         }
+    }
+}
+
+// TODO(#321): should return Result not Option(returns when it fails to get the home dir)
+pub fn history_file_path() -> Option<(PathBuf, String)> {
+    const HISTORY_FILE_NAME: &str = "history.toml";
+
+    match env::var("FZF_MAKE_IS_TESTING") {
+        Ok(_) => {
+            // When testing
+            let cwd = std::env::current_dir().unwrap();
+            Some((
+                cwd.join(PathBuf::from("test_dir")),
+                HISTORY_FILE_NAME.to_string(),
+            ))
+        }
+        _ => home_dir().map(|home_dir| {
+            (
+                home_dir.join(PathBuf::from(".config/fzf-make")),
+                HISTORY_FILE_NAME.to_string(),
+            )
+        }),
     }
 }
 

--- a/src/file/toml.rs
+++ b/src/file/toml.rs
@@ -108,7 +108,7 @@ impl HistoryCommand {
     }
 }
 
-// TODO(#321): should return Result not Option(returns when it fails to get the home dir)
+// TODO: should return Result not Option(returns when it fails to get the home dir)
 pub fn history_file_path() -> Option<(PathBuf, String)> {
     const HISTORY_FILE_NAME: &str = "history.toml";
 

--- a/src/file/toml.rs
+++ b/src/file/toml.rs
@@ -52,12 +52,6 @@ impl Histories {
     }
 }
 
-// impl std::default::Default for Histories {
-//     fn default() -> Self {
-//         Self { histories: vec![] }
-//     }
-// }
-
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 struct History {
     path: PathBuf,

--- a/src/file/toml.rs
+++ b/src/file/toml.rs
@@ -135,7 +135,7 @@ pub fn parse_history(content: String) -> Result<Histories> {
     Ok(histories)
 }
 
-pub fn store_history(
+pub fn create_or_update_history_file(
     history_directory_path: PathBuf,
     history_file_name: String,
     new_history: histories::Histories,

--- a/src/file/toml.rs
+++ b/src/file/toml.rs
@@ -30,7 +30,7 @@ impl Histories {
 #[serde(rename_all = "kebab-case")]
 struct History {
     path: String,
-    executed_targets: Vec<command::Command>,
+    executed_targets: Vec<Histories::>,
 }
 
 pub fn parse_history(content: String) -> Result<Vec<(PathBuf, Vec<command::Command>)>> {

--- a/src/file/toml.rs
+++ b/src/file/toml.rs
@@ -159,6 +159,7 @@ mod test {
     use super::*;
     use crate::model::runner_type;
     use anyhow::Result;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn parse_history_test() {

--- a/src/file/toml.rs
+++ b/src/file/toml.rs
@@ -115,7 +115,7 @@ pub fn history_file_path() -> Option<(PathBuf, String)> {
     match env::var("FZF_MAKE_IS_TESTING") {
         Ok(_) => {
             // When testing
-            let cwd = std::env::current_dir().unwrap();
+            let cwd = env::current_dir().unwrap();
             Some((
                 cwd.join(PathBuf::from("test_dir")),
                 HISTORY_FILE_NAME.to_string(),

--- a/src/file/toml.rs
+++ b/src/file/toml.rs
@@ -98,12 +98,19 @@ pub fn parse_history(content: String) -> Result<histories::Histories> {
     Ok(Histories::into(histories))
 }
 
-#[allow(dead_code)] // TODO(#321): remove
 pub fn store_history(
     history_directory_path: PathBuf,
     history_file_name: String,
-    histories: histories::Histories,
+    histories: histories::History,
 ) -> Result<()> {
+
+    TODO:
+    TODO:
+    TODO:
+    TODO:
+    // 1. 改めて履歴ファイルからhistoriesを取得する
+    // 2. cwdの履歴を更新する
+    // 3. historiesを保存する
     let histories = Histories::from(histories);
 
     if !history_directory_path.is_dir() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,11 @@ mod controller;
 mod file;
 mod model;
 mod usecase;
-
-use crate::controller::controller_main;
 use std::panic;
 
 fn main() {
     let result = panic::catch_unwind(|| {
-        controller_main::run();
+        controller::controller_main::run();
     });
     match result {
         Ok(_) => {}

--- a/src/model/command.rs
+++ b/src/model/command.rs
@@ -1,10 +1,7 @@
-use serde::{Deserialize, Serialize};
 use std::{fmt, path::PathBuf};
 
 use super::runner_type;
 
-#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
 pub struct Command {
     pub runner_type: runner_type::RunnerType,
     pub name: String,

--- a/src/model/command.rs
+++ b/src/model/command.rs
@@ -1,6 +1,5 @@
-use std::{fmt, path::PathBuf};
-
 use super::runner_type;
+use std::{fmt, path::PathBuf};
 
 #[derive(PartialEq, Clone, Debug)]
 pub struct Command {

--- a/src/model/command.rs
+++ b/src/model/command.rs
@@ -12,13 +12,13 @@ pub struct Command {
 impl Command {
     pub fn new(
         runner_type: runner_type::RunnerType,
-        command_name: String,
+        name: String,
         file_name: PathBuf,
         line_number: u32,
     ) -> Self {
         Self {
             runner_type,
-            name: command_name,
+            name,
             file_name,
             line_number,
         }
@@ -27,6 +27,6 @@ impl Command {
 
 impl fmt::Display for Command {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "({}) {}", self.runner_type, self.name)
+        write!(f, "[{}] {}", self.runner_type, self.name)
     }
 }

--- a/src/model/command.rs
+++ b/src/model/command.rs
@@ -2,6 +2,7 @@ use std::{fmt, path::PathBuf};
 
 use super::runner_type;
 
+#[derive(PartialEq, Clone, Debug)]
 pub struct Command {
     pub runner_type: runner_type::RunnerType,
     pub name: String,

--- a/src/model/command.rs
+++ b/src/model/command.rs
@@ -1,8 +1,10 @@
+use serde::{Deserialize, Serialize};
 use std::{fmt, path::PathBuf};
 
 use super::runner_type;
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct Command {
     pub runner_type: runner_type::RunnerType,
     pub name: String,

--- a/src/model/file_util.rs
+++ b/src/model/file_util.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, Result};
-
 use std::{fs::read_to_string, path::PathBuf};
 
 pub fn path_to_content(path: PathBuf) -> Result<String> {

--- a/src/model/histories.rs
+++ b/src/model/histories.rs
@@ -30,30 +30,36 @@ impl Histories {
     //     histories
     // }
 
-    // pub fn append(&self, path: &PathBuf, executed_target: &str) -> Option<Self> {
-    //     let mut new_histories = self.histories.clone();
-    //
-    //     new_histories
-    //         .iter()
-    //         .position(|h| h.path == *path)
-    //         .map(|index| {
-    //             let new_history = new_histories[index].append(executed_target.to_string());
-    //             new_histories[index] = new_history;
-    //
-    //             Self {
-    //                 histories: new_histories,
-    //             }
-    //         })
-    // }
+    pub fn append(
+        &self,
+        current_dir: PathBuf,
+        histories_before_update: Vec<command::Command>,
+        command: command::Command,
+    ) -> Self {
+        let new_history_commands: Vec<HistoryCommand> = [vec![command], histories_before_update]
+            .concat()
+            .iter()
+            .map(|c| HistoryCommand::from(c.clone()))
+            .collect();
+        let history = History {
+            path: current_dir.clone(),
+            commands: new_history_commands,
+        };
 
-    // pub fn to_tuple(&self) -> Vec<(PathBuf, Vec<String>)> {
-    //     let mut result = Vec::new();
-    //
-    //     for history in &self.histories {
-    //         result.push((history.path.clone(), history.executed_targets.clone()));
-    //     }
-    //     result
-    // }
+        let mut new_histories = self.histories.clone();
+        match new_histories.iter().position(|h| h.path == history.path) {
+            Some(index) => {
+                new_histories[index] = history;
+            }
+            None => {
+                new_histories.insert(0, history);
+            }
+        }
+
+        Histories {
+            histories: new_histories,
+        }
+    }
 }
 
 // TODO(#321): should return Result not Option(returns when it fails to get the home dir)

--- a/src/model/histories.rs
+++ b/src/model/histories.rs
@@ -7,6 +7,7 @@ use super::{command, runner_type};
 /// For now, we can define this as tuple like `pub struct Histories(Vec<History>);` but we don't.
 /// We respect that we can add some fields in the future easily.
 #[derive(Clone, PartialEq, Debug)]
+// TODO: 削除する？
 pub struct Histories {
     pub histories: Vec<History>,
 }
@@ -91,12 +92,13 @@ impl History {
         }
     }
 
-    fn from(histories: (PathBuf, Vec<command::Command>)) -> Self {
-        Self {
-            path: histories.0,
-            executed_commands: histories.1,
-        }
-    }
+    // TODO: 不要そうだったら消す
+    // fn from(histories: (PathBuf, Vec<command::Command>)) -> Self {
+    //     Self {
+    //         path: histories.0,
+    //         executed_commands: histories.1,
+    //     }
+    // }
 
     // TODO(#321): remove
     #[allow(dead_code)]

--- a/src/model/histories.rs
+++ b/src/model/histories.rs
@@ -5,30 +5,11 @@ use std::path::PathBuf;
 /// For now, we can define this as tuple like `pub struct Histories(Vec<History>);` but we don't.
 /// We respect that we can add some fields in the future easily.
 #[derive(Clone, PartialEq, Debug)]
-// TODO: 削除する？とはいえappendなどのメソッドはapp側ではなくここに実装したほうが凝集度が高くてよさそう。
-//
 pub struct Histories {
     pub histories: Vec<History>,
 }
 
 impl Histories {
-    // TODO(#321): Make this fn returns Vec<runner::Command>
-    // pub fn get_histories(&self, paths: Vec<PathBuf>) -> Vec<String> {
-    //     let mut histories: Vec<String> = Vec::new();
-    //
-    //     for path in paths {
-    //         let executed_targets = self
-    //             .histories
-    //             .iter()
-    //             .find(|h| h.path == path)
-    //             .map(|h| h.executed_targets.clone())
-    //             .unwrap_or(Vec::new());
-    //         histories = [histories, executed_targets].concat();
-    //     }
-    //
-    //     histories
-    // }
-
     // TODO: ut
     pub fn append(
         &self,

--- a/src/model/histories.rs
+++ b/src/model/histories.rs
@@ -1,7 +1,8 @@
+use serde::{Deserialize, Serialize};
 use simple_home_dir::home_dir;
 use std::{env, path::PathBuf};
 
-use super::command;
+use super::{command, runner_type};
 
 #[derive(Clone, PartialEq, Debug)]
 pub struct Histories {
@@ -66,6 +67,7 @@ impl Histories {
     }
 
     pub fn default(path: PathBuf) -> Self {
+        // TODO: should receive cwd instead of makefile_path
         let histories = vec![History::default(path)];
         Self { histories }
     }
@@ -111,8 +113,8 @@ pub fn history_file_path() -> Option<(PathBuf, String)> {
 
 #[derive(Clone, PartialEq, Debug)]
 struct History {
-    path: PathBuf,                           // TODO: rename to working_directory
-    executed_targets: Vec<command::Command>, // TODO: rename to executed_commands
+    path: PathBuf,                         // TODO: rename to working_directory
+    executed_targets: Vec<HistoryCommand>, // TODO: rename to executed_commands
 }
 
 impl History {
@@ -147,6 +149,16 @@ impl History {
             executed_targets,
         }
     }
+}
+
+/// In the history file, the command has only the name of the command and the runner type.
+/// Because its file name where it's defined and file number is variable.
+/// So we search them every time fzf-make is launched.
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct HistoryCommand {
+    runner_type: runner_type::RunnerType,
+    name: String,
 }
 
 #[cfg(test)]

--- a/src/model/histories.rs
+++ b/src/model/histories.rs
@@ -7,7 +7,8 @@ use super::{command, runner_type};
 /// For now, we can define this as tuple like `pub struct Histories(Vec<History>);` but we don't.
 /// We respect that we can add some fields in the future easily.
 #[derive(Clone, PartialEq, Debug)]
-// TODO: 削除する？
+// TODO: 削除する？とはいえappendなどのメソッドはapp側ではなくここに実装したほうが凝集度が高くてよさそう。
+//
 pub struct Histories {
     pub histories: Vec<History>,
 }
@@ -126,6 +127,15 @@ impl History {
 pub struct HistoryCommand {
     pub runner_type: runner_type::RunnerType,
     pub name: String,
+}
+
+impl HistoryCommand {
+    pub fn from(command: command::Command) -> Self {
+        Self {
+            runner_type: command.runner_type,
+            name: command.name,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/model/histories.rs
+++ b/src/model/histories.rs
@@ -53,13 +53,6 @@ impl Histories {
     //     }
     //     result
     // }
-
-    pub fn get_latest_command(&self, path: &PathBuf) -> Option<&HistoryCommand> {
-        self.histories
-            .iter()
-            .find(|h| h.path == *path)
-            .map(|h| h.executed_commands.first())?
-    }
 }
 
 // TODO(#321): should return Result not Option(returns when it fails to get the home dir)

--- a/src/model/histories.rs
+++ b/src/model/histories.rs
@@ -45,6 +45,8 @@ impl Histories {
 #[derive(Clone, PartialEq, Debug)]
 pub struct History {
     pub path: PathBuf,
+    /// The commands are sorted in descending order of execution time.
+    /// This means that the first element is the most recently executed command.
     pub commands: Vec<HistoryCommand>,
 }
 

--- a/src/model/histories.rs
+++ b/src/model/histories.rs
@@ -55,14 +55,6 @@ pub struct History {
 }
 
 impl History {
-    // #[allow(dead_code)]
-    // fn from(histories: (PathBuf, Vec<command::Command>)) -> Self {
-    //     Self {
-    //         path: histories.0,
-    //         commands: histories.1,
-    //     }
-    // }
-
     // TODO: ut
     fn append(&self, executed_command: command::Command) -> Self {
         let mut updated_commands = self.commands.clone();

--- a/src/model/histories.rs
+++ b/src/model/histories.rs
@@ -69,9 +69,10 @@ impl History {
     }
 }
 
-/// In the history file, the command has only the name of the command and the runner type.
-/// Because its file name where it's defined and file number is variable.
-/// So we search them every time fzf-make is launched.
+/// In the history file, the command has only the name of the command and the runner type though
+/// command::Command has `file_name`, `line_number` as well.
+/// Because its file name where it's defined and line number is variable.
+/// So we search them every time fzf-make is launched instead of storing them in the history file.
 #[derive(PartialEq, Clone, Debug)]
 pub struct HistoryCommand {
     pub runner_type: runner_type::RunnerType,

--- a/src/model/histories.rs
+++ b/src/model/histories.rs
@@ -428,290 +428,291 @@ mod test {
     //         )
     //     }
     // }
-    #[test]
-    fn history_append_test() {
-        struct Case {
-            title: &'static str,
-            appending_target: command::Command,
-            history: History,
-            expect: History,
-        }
-        let path = PathBuf::from("/Users/user/code/fzf-make".to_string());
-        let cases = vec![
-            Case {
-                title: "Append to head",
-                appending_target: command::Command::new(
-                    runner_type::RunnerType::Make,
-                    "history2".to_string(),
-                    PathBuf::from("Makefile"),
-                    1,
-                ),
-                history: History {
-                    path: path.clone(),
-                    executed_targets: vec![
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history0".to_string(),
-                            PathBuf::from("Makefile"),
-                            1,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history1".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                    ],
-                },
-                expect: History {
-                    path: path.clone(),
-                    executed_targets: vec![
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history2".to_string(),
-                            PathBuf::from("Makefile"),
-                            1,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history0".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history1".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                    ],
-                },
-            },
-            Case {
-                title: "Append to head(Append to empty)",
-                appending_target: command::Command::new(
-                    runner_type::RunnerType::Make,
-                    "history0".to_string(),
-                    PathBuf::from("Makefile"),
-                    4,
-                ),
-                history: History {
-                    path: path.clone(),
-                    executed_targets: vec![],
-                },
-                expect: History {
-                    path: path.clone(),
-                    executed_targets: vec![command::Command::new(
-                        runner_type::RunnerType::Make,
-                        "history0".to_string(),
-                        PathBuf::from("Makefile"),
-                        4,
-                    )],
-                },
-            },
-            Case {
-                title: "Append to head(Remove duplicated)",
-                appending_target: command::Command::new(
-                    runner_type::RunnerType::Make,
-                    "history1".to_string(),
-                    PathBuf::from("Makefile"),
-                    4,
-                ),
-                history: History {
-                    path: path.clone(),
-                    executed_targets: vec![
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history0".to_string(),
-                            PathBuf::from("Makefile"),
-                            1,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history1".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history2".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                    ],
-                },
-                expect: History {
-                    path: path.clone(),
-                    executed_targets: vec![
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history1".to_string(),
-                            PathBuf::from("Makefile"),
-                            1,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history0".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history2".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                    ],
-                },
-            },
-            Case {
-                title: "Truncate when length exceeds 10",
-                appending_target: command::Command::new(
-                    runner_type::RunnerType::Make,
-                    "history11".to_string(),
-                    PathBuf::from("Makefile"),
-                    1,
-                ),
-                history: History {
-                    path: path.clone(),
-                    executed_targets: vec![
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history0".to_string(),
-                            PathBuf::from("Makefile"),
-                            1,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history1".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history2".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history3".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history4".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history5".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history6".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history7".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history8".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history9".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                    ],
-                },
-                expect: History {
-                    path: path.clone(),
-                    executed_targets: vec![
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history11".to_string(),
-                            PathBuf::from("Makefile"),
-                            1,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history0".to_string(),
-                            PathBuf::from("Makefile"),
-                            1,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history1".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history2".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history3".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history4".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history5".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history6".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history7".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                        command::Command::new(
-                            runner_type::RunnerType::Make,
-                            "history8".to_string(),
-                            PathBuf::from("Makefile"),
-                            4,
-                        ),
-                    ],
-                },
-            },
-        ];
-
-        for case in cases {
-            assert_eq!(
-                case.expect,
-                case.history.append(case.appending_target),
-                "\nFailed: 🚨{:?}🚨\n",
-                case.title,
-            )
-        }
-    }
+    // TODO(#321): comment in this test
+    // #[test]
+    // fn history_append_test() {
+    //     struct Case {
+    //         title: &'static str,
+    //         appending_target: command::Command,
+    //         history: History,
+    //         expect: History,
+    //     }
+    //     let path = PathBuf::from("/Users/user/code/fzf-make".to_string());
+    //     let cases = vec![
+    //         Case {
+    //             title: "Append to head",
+    //             appending_target: command::Command::new(
+    //                 runner_type::RunnerType::Make,
+    //                 "history2".to_string(),
+    //                 PathBuf::from("Makefile"),
+    //                 1,
+    //             ),
+    //             history: History {
+    //                 path: path.clone(),
+    //                 executed_targets: vec![
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history0".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         1,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history1".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                 ],
+    //             },
+    //             expect: History {
+    //                 path: path.clone(),
+    //                 executed_targets: vec![
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history2".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         1,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history0".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history1".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                 ],
+    //             },
+    //         },
+    //         Case {
+    //             title: "Append to head(Append to empty)",
+    //             appending_target: command::Command::new(
+    //                 runner_type::RunnerType::Make,
+    //                 "history0".to_string(),
+    //                 PathBuf::from("Makefile"),
+    //                 4,
+    //             ),
+    //             history: History {
+    //                 path: path.clone(),
+    //                 executed_targets: vec![],
+    //             },
+    //             expect: History {
+    //                 path: path.clone(),
+    //                 executed_targets: vec![command::Command::new(
+    //                     runner_type::RunnerType::Make,
+    //                     "history0".to_string(),
+    //                     PathBuf::from("Makefile"),
+    //                     4,
+    //                 )],
+    //             },
+    //         },
+    //         Case {
+    //             title: "Append to head(Remove duplicated)",
+    //             appending_target: command::Command::new(
+    //                 runner_type::RunnerType::Make,
+    //                 "history1".to_string(),
+    //                 PathBuf::from("Makefile"),
+    //                 4,
+    //             ),
+    //             history: History {
+    //                 path: path.clone(),
+    //                 executed_targets: vec![
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history0".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         1,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history1".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history2".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                 ],
+    //             },
+    //             expect: History {
+    //                 path: path.clone(),
+    //                 executed_targets: vec![
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history1".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         1,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history0".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history2".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                 ],
+    //             },
+    //         },
+    //         Case {
+    //             title: "Truncate when length exceeds 10",
+    //             appending_target: command::Command::new(
+    //                 runner_type::RunnerType::Make,
+    //                 "history11".to_string(),
+    //                 PathBuf::from("Makefile"),
+    //                 1,
+    //             ),
+    //             history: History {
+    //                 path: path.clone(),
+    //                 executed_targets: vec![
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history0".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         1,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history1".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history2".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history3".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history4".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history5".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history6".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history7".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history8".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history9".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                 ],
+    //             },
+    //             expect: History {
+    //                 path: path.clone(),
+    //                 executed_targets: vec![
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history11".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         1,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history0".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         1,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history1".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history2".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history3".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history4".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history5".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history6".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history7".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                     command::Command::new(
+    //                         runner_type::RunnerType::Make,
+    //                         "history8".to_string(),
+    //                         PathBuf::from("Makefile"),
+    //                         4,
+    //                     ),
+    //                 ],
+    //             },
+    //         },
+    //     ];
+    //
+    //     for case in cases {
+    //         assert_eq!(
+    //             case.expect,
+    //             case.history.append(case.appending_target),
+    //             "\nFailed: 🚨{:?}🚨\n",
+    //             case.title,
+    //         )
+    //     }
+    // }
 }

--- a/src/model/histories.rs
+++ b/src/model/histories.rs
@@ -49,7 +49,6 @@ pub struct History {
 }
 
 impl History {
-    // TODO: ut
     fn append(&self, executed_command: command::Command) -> Self {
         let mut updated_commands = self.commands.clone();
         // removes the executed_command from the history
@@ -96,9 +95,9 @@ mod test {
     fn histories_append_test() {
         struct Case {
             title: &'static str,
-            histories: Histories,
+            before: Histories,
             command_to_append: command::Command,
-            expect: Histories,
+            after: Histories,
         }
 
         let path_to_append = PathBuf::from("/Users/user/code/fzf-make".to_string());
@@ -107,7 +106,7 @@ mod test {
                 // Use raw string literal as workaround for
                 // https://github.com/rust-lang/rustfmt/issues/4800.
                 title: r#"The command executed is appended to the existing history if there is history for cwd."#,
-                histories: Histories {
+                before: Histories {
                     histories: vec![
                         History {
                             path: PathBuf::from("/Users/user/code/rustc".to_string()),
@@ -131,7 +130,7 @@ mod test {
                     file_name: PathBuf::from("Makefile"),
                     line_number: 1,
                 },
-                expect: Histories {
+                after: Histories {
                     histories: vec![
                         History {
                             path: PathBuf::from("/Users/user/code/rustc".to_string()),
@@ -158,7 +157,7 @@ mod test {
             },
             Case {
                 title: r#"A new history is appended if there is no history for cwd."#,
-                histories: Histories {
+                before: Histories {
                     histories: vec![History {
                         path: PathBuf::from("/Users/user/code/rustc".to_string()),
                         commands: vec![HistoryCommand {
@@ -173,7 +172,7 @@ mod test {
                     file_name: PathBuf::from("Makefile"),
                     line_number: 1,
                 },
-                expect: Histories {
+                after: Histories {
                     histories: vec![
                         History {
                             path: path_to_append.clone(),
@@ -196,8 +195,8 @@ mod test {
 
         for case in cases {
             assert_eq!(
-                case.expect,
-                case.histories
+                case.after,
+                case.before
                     .append(path_to_append.clone(), case.command_to_append),
                 "\nFailed: 🚨{:?}🚨\n",
                 case.title,
@@ -205,291 +204,226 @@ mod test {
         }
     }
 
-    // TODO(#321): comment in this test
-    // #[test]
-    // fn history_append_test() {
-    //     struct Case {
-    //         title: &'static str,
-    //         appending_target: command::Command,
-    //         history: History,
-    //         expect: History,
-    //     }
-    //     let path = PathBuf::from("/Users/user/code/fzf-make".to_string());
-    //     let cases = vec![
-    //         Case {
-    //             title: "Append to head",
-    //             appending_target: command::Command::new(
-    //                 runner_type::RunnerType::Make,
-    //                 "history2".to_string(),
-    //                 PathBuf::from("Makefile"),
-    //                 1,
-    //             ),
-    //             history: History {
-    //                 path: path.clone(),
-    //                 executed_targets: vec![
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history0".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         1,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history1".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                 ],
-    //             },
-    //             expect: History {
-    //                 path: path.clone(),
-    //                 executed_targets: vec![
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history2".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         1,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history0".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history1".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                 ],
-    //             },
-    //         },
-    //         Case {
-    //             title: "Append to head(Append to empty)",
-    //             appending_target: command::Command::new(
-    //                 runner_type::RunnerType::Make,
-    //                 "history0".to_string(),
-    //                 PathBuf::from("Makefile"),
-    //                 4,
-    //             ),
-    //             history: History {
-    //                 path: path.clone(),
-    //                 executed_targets: vec![],
-    //             },
-    //             expect: History {
-    //                 path: path.clone(),
-    //                 executed_targets: vec![command::Command::new(
-    //                     runner_type::RunnerType::Make,
-    //                     "history0".to_string(),
-    //                     PathBuf::from("Makefile"),
-    //                     4,
-    //                 )],
-    //             },
-    //         },
-    //         Case {
-    //             title: "Append to head(Remove duplicated)",
-    //             appending_target: command::Command::new(
-    //                 runner_type::RunnerType::Make,
-    //                 "history1".to_string(),
-    //                 PathBuf::from("Makefile"),
-    //                 4,
-    //             ),
-    //             history: History {
-    //                 path: path.clone(),
-    //                 executed_targets: vec![
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history0".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         1,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history1".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history2".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                 ],
-    //             },
-    //             expect: History {
-    //                 path: path.clone(),
-    //                 executed_targets: vec![
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history1".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         1,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history0".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history2".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                 ],
-    //             },
-    //         },
-    //         Case {
-    //             title: "Truncate when length exceeds 10",
-    //             appending_target: command::Command::new(
-    //                 runner_type::RunnerType::Make,
-    //                 "history11".to_string(),
-    //                 PathBuf::from("Makefile"),
-    //                 1,
-    //             ),
-    //             history: History {
-    //                 path: path.clone(),
-    //                 executed_targets: vec![
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history0".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         1,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history1".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history2".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history3".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history4".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history5".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history6".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history7".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history8".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history9".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                 ],
-    //             },
-    //             expect: History {
-    //                 path: path.clone(),
-    //                 executed_targets: vec![
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history11".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         1,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history0".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         1,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history1".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history2".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history3".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history4".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history5".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history6".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history7".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                     command::Command::new(
-    //                         runner_type::RunnerType::Make,
-    //                         "history8".to_string(),
-    //                         PathBuf::from("Makefile"),
-    //                         4,
-    //                     ),
-    //                 ],
-    //             },
-    //         },
-    //     ];
-    //
-    //     for case in cases {
-    //         assert_eq!(
-    //             case.expect,
-    //             case.history.append(case.appending_target),
-    //             "\nFailed: 🚨{:?}🚨\n",
-    //             case.title,
-    //         )
-    //     }
-    // }
+    #[test]
+    fn history_append_test() {
+        struct Case {
+            title: &'static str,
+            before: History,
+            command_to_append: command::Command,
+            after: History,
+        }
+        let path = PathBuf::from("/Users/user/code/fzf-make".to_string());
+        let cases = vec![
+            Case {
+                title: "Append to head",
+                before: History {
+                    path: path.clone(),
+                    commands: vec![
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history0".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history1".to_string(),
+                        },
+                    ],
+                },
+                command_to_append: command::Command::new(
+                    runner_type::RunnerType::Make,
+                    "history2".to_string(),
+                    PathBuf::from("Makefile"),
+                    1,
+                ),
+                after: History {
+                    path: path.clone(),
+                    commands: vec![
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history2".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history0".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history1".to_string(),
+                        },
+                    ],
+                },
+            },
+            Case {
+                title: "Append to head(Append to empty)",
+                before: History {
+                    path: path.clone(),
+                    commands: vec![],
+                },
+                command_to_append: command::Command::new(
+                    runner_type::RunnerType::Make,
+                    "history0".to_string(),
+                    PathBuf::from("Makefile"),
+                    4,
+                ),
+                after: History {
+                    path: path.clone(),
+                    commands: vec![HistoryCommand {
+                        runner_type: runner_type::RunnerType::Make,
+                        name: "history0".to_string(),
+                    }],
+                },
+            },
+            Case {
+                title: "Append to head(Remove duplicated command)",
+                before: History {
+                    path: path.clone(),
+                    commands: vec![
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history0".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history1".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history2".to_string(),
+                        },
+                    ],
+                },
+                command_to_append: command::Command::new(
+                    runner_type::RunnerType::Make,
+                    "history2".to_string(),
+                    PathBuf::from("Makefile"),
+                    1,
+                ),
+                after: History {
+                    path: path.clone(),
+                    commands: vec![
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history2".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history0".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history1".to_string(),
+                        },
+                    ],
+                },
+            },
+            Case {
+                title: "Truncate when length exceeds 10",
+                before: History {
+                    path: path.clone(),
+                    commands: vec![
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history0".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history1".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history2".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history3".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history4".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history5".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history6".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history7".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history8".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history9".to_string(),
+                        },
+                    ],
+                },
+                command_to_append: command::Command::new(
+                    runner_type::RunnerType::Make,
+                    "history10".to_string(),
+                    PathBuf::from("Makefile"),
+                    1,
+                ),
+                after: History {
+                    path: path.clone(),
+                    commands: vec![
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history10".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history0".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history1".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history2".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history3".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history4".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history5".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history6".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history7".to_string(),
+                        },
+                        HistoryCommand {
+                            runner_type: runner_type::RunnerType::Make,
+                            name: "history8".to_string(),
+                        },
+                    ],
+                },
+            },
+        ];
+
+        for case in cases {
+            assert_eq!(
+                case.after,
+                case.before.append(case.command_to_append),
+                "\nFailed: 🚨{:?}🚨\n",
+                case.title,
+            )
+        }
+    }
 }

--- a/src/model/histories.rs
+++ b/src/model/histories.rs
@@ -1,7 +1,6 @@
+use super::{command, runner_type};
 use simple_home_dir::home_dir;
 use std::{env, path::PathBuf};
-
-use super::{command, runner_type};
 
 /// Histories is a all collection of History. This equals whole content of history.toml.
 /// For now, we can define this as tuple like `pub struct Histories(Vec<History>);` but we don't.
@@ -82,16 +81,16 @@ pub fn history_file_path() -> Option<(PathBuf, String)> {
 #[derive(Clone, PartialEq, Debug)]
 pub struct History {
     pub path: PathBuf,
-    pub executed_commands: Vec<HistoryCommand>, // TODO: rename to executed_commands
+    pub commands: Vec<HistoryCommand>, // TODO: rename to executed_commands
 }
 
 impl History {
-    fn default(path: PathBuf) -> Self {
-        Self {
-            path,
-            executed_commands: Vec::new(),
-        }
-    }
+    // fn default(path: PathBuf) -> Self {
+    //     Self {
+    //         path,
+    //         commands: Vec::new(),
+    //     }
+    // }
 
     // TODO: 不要そうだったら消す
     // fn from(histories: (PathBuf, Vec<command::Command>)) -> Self {
@@ -103,10 +102,10 @@ impl History {
 
     // TODO(#321): remove
     #[allow(dead_code)]
-    fn append(&self, executed_target: command::Command) -> Self {
-        let mut executed_targets = self.executed_commands.clone();
-        executed_targets.retain(|t| *t != executed_target);
-        executed_targets.insert(0, executed_target.clone());
+    fn append(&self, _executed_target: command::Command) -> Self {
+        let mut executed_targets = self.commands.clone();
+        // executed_targets.retain(|t| *t != executed_target);
+        // executed_targets.insert(0, executed_target.clone());
 
         const MAX_LENGTH: usize = 10;
         if MAX_LENGTH < executed_targets.len() {
@@ -115,7 +114,7 @@ impl History {
 
         Self {
             path: self.path.clone(),
-            executed_commands: executed_targets,
+            commands: executed_targets,
         }
     }
 }

--- a/src/model/make.rs
+++ b/src/model/make.rs
@@ -171,6 +171,7 @@ fn line_to_including_file_paths(line: String) -> Option<Vec<PathBuf>> {
 mod test {
     use super::*;
     use crate::model::runner_type;
+    use pretty_assertions::assert_eq;
     use std::{
         env,
         fs::{self, File},

--- a/src/model/make.rs
+++ b/src/model/make.rs
@@ -130,7 +130,7 @@ impl Make {
 /// The path should be relative path from current directory where make command is executed.
 /// So the path can be treated as it is.
 /// NOTE: path include `..` is not supported for now like `include ../c.mk`.
-pub fn content_to_include_file_paths(file_content: String) -> Vec<PathBuf> {
+fn content_to_include_file_paths(file_content: String) -> Vec<PathBuf> {
     let mut result: Vec<PathBuf> = Vec::new();
     for line in file_content.lines() {
         let Some(include_files) = line_to_including_file_paths(line.to_string()) else {

--- a/src/model/make.rs
+++ b/src/model/make.rs
@@ -69,6 +69,7 @@ impl Make {
             let file_name_string = file_name.to_str().unwrap();
             if makefile_name_options.contains(&file_name_string) {
                 let current_dir = match env::current_dir() {
+                    // TODO: use model.current_dir
                     Err(_) => return None,
                     Ok(d) => d,
                 };

--- a/src/model/runner.rs
+++ b/src/model/runner.rs
@@ -6,8 +6,6 @@ use std::path::PathBuf;
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum Runner {
-    // TODO(#321): Use associated constants if possible.
-    // ref: https://doc.rust-lang.org/reference/items/associated-items.html#associated-constants
     MakeCommand(make::Make),
     PnpmCommand(pnpm::Pnpm),
 }

--- a/src/model/runner_type.rs
+++ b/src/model/runner_type.rs
@@ -20,7 +20,7 @@ impl RunnerType {
                 }
                 None
             }
-            RunnerType::Pnpm => todo!(),
+            RunnerType::Pnpm => todo!("implement and write test"),
         }
     }
 }

--- a/src/model/runner_type.rs
+++ b/src/model/runner_type.rs
@@ -1,8 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-// TODO(#321): remove
-#[allow(dead_code)]
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum RunnerType {

--- a/src/model/runner_type.rs
+++ b/src/model/runner_type.rs
@@ -1,11 +1,29 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+use super::runner;
+
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum RunnerType {
     Make,
     Pnpm,
+}
+
+impl RunnerType {
+    pub fn to_runner(&self, runners: &Vec<runner::Runner>) -> Option<runner::Runner> {
+        match self {
+            RunnerType::Make => {
+                for r in runners {
+                    if matches!(r, runner::Runner::MakeCommand(_)) {
+                        return Some(r.clone());
+                    }
+                }
+                None
+            }
+            RunnerType::Pnpm => todo!(),
+        }
+    }
 }
 
 impl fmt::Display for RunnerType {

--- a/src/model/runner_type.rs
+++ b/src/model/runner_type.rs
@@ -1,7 +1,6 @@
+use super::runner;
 use serde::{Deserialize, Serialize};
 use std::fmt;
-
-use super::runner;
 
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]

--- a/src/model/runner_type.rs
+++ b/src/model/runner_type.rs
@@ -4,6 +4,7 @@ use std::fmt;
 // TODO(#321): remove
 #[allow(dead_code)]
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum RunnerType {
     Make,
     Pnpm,

--- a/src/model/runner_type.rs
+++ b/src/model/runner_type.rs
@@ -1,8 +1,9 @@
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 // TODO(#321): remove
 #[allow(dead_code)]
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub enum RunnerType {
     Make,
     Pnpm,

--- a/src/model/target.rs
+++ b/src/model/target.rs
@@ -88,6 +88,7 @@ fn line_to_target(line: String) -> Option<String> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn content_to_targets_test() {

--- a/src/model/target.rs
+++ b/src/model/target.rs
@@ -1,8 +1,6 @@
-use std::path::PathBuf;
-
-use regex::Regex;
-
 use super::{command, runner_type};
+use regex::Regex;
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Targets(pub Vec<command::Command>);

--- a/src/usecase/help.rs
+++ b/src/usecase/help.rs
@@ -30,7 +30,7 @@ USAGE:
 
 SUBCOMMANDS:
     repeat, --repeat, -r
-        Execute the last executed make target.
+        Execute the last executed command.
     history, --history, -h
         Launch fzf-make with the history pane focused.
     help, --help, -h

--- a/src/usecase/repeat.rs
+++ b/src/usecase/repeat.rs
@@ -1,10 +1,9 @@
-use crate::usecase::usecase_main::Usecase;
-use anyhow::{anyhow, Result};
-
 use super::tui::{
     app::{AppState, Model},
     config,
 };
+use crate::usecase::usecase_main::Usecase;
+use anyhow::{anyhow, Result};
 
 pub struct Repeat;
 

--- a/src/usecase/repeat.rs
+++ b/src/usecase/repeat.rs
@@ -25,8 +25,8 @@ impl Usecase for Repeat {
             Ok(model) => match model.app_state {
                 AppState::SelectTarget(state) => {
                     match (
-                        state.runners.first(),
-                        state.histories.get_latest_target(&state.current_dir),
+                        state.runners.first(), // TODO: firstではなく最後に実行されたcommandのrunnerを使うべき
+                        state.histories.get_latest_command(&state.current_dir),
                     ) {
                         (Some(r), Some(h)) => r.execute(h),
                         (_, _) => Err(anyhow!("fzf-make has not been executed in this path yet.")),

--- a/src/usecase/repeat.rs
+++ b/src/usecase/repeat.rs
@@ -23,7 +23,7 @@ impl Usecase for Repeat {
         match Model::new(config::Config::default()) {
             Err(e) => Err(e),
             Ok(model) => match model.app_state {
-                AppState::SelectTarget(state) => match state.get_latest_command() {
+                AppState::SelectCommand(state) => match state.get_latest_command() {
                     Some(c) => match state.get_runner(&c.runner_type) {
                         Some(runner) => runner.execute(c),
                         None => Err(anyhow!("runner not found.")),

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -139,15 +139,15 @@ impl Model<'_> {
         self.app_state = AppState::ShouldQuit;
     }
 
-    pub fn should_quit(&self) -> bool {
+    fn should_quit(&self) -> bool {
         self.app_state == AppState::ShouldQuit
     }
 
-    pub fn is_command_selected(&self) -> bool {
+    fn is_command_selected(&self) -> bool {
         matches!(self.app_state, AppState::ExecuteCommand(_))
     }
 
-    pub fn command_to_execute(&self) -> Option<(runner::Runner, command::Command)> {
+    fn command_to_execute(&self) -> Option<(runner::Runner, command::Command)> {
         match &self.app_state {
             AppState::ExecuteCommand(command) => {
                 let command = command.clone();

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -298,14 +298,9 @@ pub struct SelectTargetState<'a> {
     pub runners: Vec<runner::Runner>,
     pub search_text_area: TextArea_<'a>,
     pub targets_list_state: ListState,
-    // このフィールドをVec<Histories>にするかこのままにするか
-    // 前者
-    // 実行時に変換が必要
-    // 後者
-    // 保存時に変換が必要
-    // 存在しないcommandを非表示にできる
-    // 将来的にpreviewできる
-    // TODO: ↑をコメントとして記述する
+    /// This field could have been of type `Vec<Histories>`, but it was intentionally made of type `Vec<command::Command>`.
+    /// This is because it allows for future features such as displaying the contents of history in the preview window
+    /// or hiding commands that existed at the time of execution but no longer exist.
     pub histories: Vec<command::Command>,
     pub histories_list_state: ListState,
 }

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -396,15 +396,17 @@ impl SelectTargetState<'_> {
 
     // TODO(#321): comment in this method
     // TODO: This method should return Result when it fails.
-    // pub fn append_history(&self, command: &str) -> Option<Histories> {
-    //     match &self.histories {
-    //         Some(histories) => {
-    //             histories.append(&self.runners[0].path(), command)
-    //             // TODO(#321): For now, it is &self.runners[0] to pass the compilation, but it should be taken from runner::Command::path()
-    //         }
-    //         _ => None,
-    //     }
-    // }
+    pub fn append_history(&self, command: &command::Command) -> Option<Histories> {
+        TODO: そのpathのhistoryをgetする
+        TODO: そのpathのhistoryがない場合はここで初期化して追加する
+        match &self.histories {
+            Some(histories) => {
+                histories.append(&self.runners[0].path(), command)
+                // TODO(#321): For now, it is &self.runners[0] to pass the compilation, but it should be taken from runner::Command::path()
+            }
+            _ => None,
+        }
+    }
 
     fn selected_target(&self) -> Option<command::Command> {
         match self.targets_list_state.selected() {
@@ -585,18 +587,18 @@ impl SelectTargetState<'_> {
         self.search_text_area.0.input(key_event);
     }
 
-    fn store_history(&mut self, _command: &command::Command) {
-        // TODO(#321): implement when history function is implemented
+    fn store_history(&mut self, command: &command::Command) {
         // NOTE: self.get_selected_target should be called before self.append_history.
         // Because self.histories_list_state.selected keeps the selected index of the history list
         // before update.
-        // if let Some(h) = self.append_history(command) {
-        //     self.histories = Some(h)
-        // };
-        // if let (Some((dir, file_name)), Some(h)) = (history_file_path(), &self.histories) {
-        //     // TODO: handle error
-        //     let _ = toml::store_history(dir, file_name, h.to_tuple());
-        // };
+        // TODO(#321): implement when history function is implemented
+        if let Some(h) = self.append_history(command) {
+            self.histories = Some(h)
+        };
+        if let (Some((dir, file_name)), Some(h)) = (history_file_path(), &self.histories) {
+            // TODO: handle error
+            let _ = toml::store_history(dir, file_name, h.to_tuple());
+        };
     }
 
     fn reset_selection(&mut self) {

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -136,7 +136,6 @@ impl Model<'_> {
     }
 
     fn transition_to_should_quit_state(&mut self) {
-        // TODO: remove mut
         self.app_state = AppState::ShouldQuit;
     }
 

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -677,9 +677,9 @@ impl<'a> PartialEq for TextArea_<'a> {
 
 #[cfg(test)]
 mod test {
-    use crate::model::runner_type;
-
     use super::*;
+    use crate::model::runner_type;
+    use pretty_assertions::assert_eq;
     use std::env;
 
     #[test]

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -335,7 +335,7 @@ impl SelectCommandState<'_> {
             Ok(d) => d,
             Err(e) => bail!("Failed to get current directory: {}", e),
         };
-        let makefile = match Make::create_makefile(current_dir.clone()) {
+        let makefile = match Make::new(current_dir.clone()) {
             Err(e) => return Err(e),
             Ok(f) => f,
         };

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -82,6 +82,7 @@ impl Model<'_> {
         }
     }
 
+    // TODO: pass cwd instead of makefile_path
     fn get_histories(makefile_path: PathBuf) -> Histories {
         match history_file_path() {
             Some((history_file_dir, history_file_name)) => {

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -610,8 +610,29 @@ impl SelectTargetState<'_> {
         self.search_text_area.0.lines().join("")
     }
 
+    pub fn get_latest_command(&self) -> Option<&command::Command> {
+        Some(self.histories.first()?)
+    }
+
+    pub fn get_runner(&self, runner_type: &runner_type::RunnerType) -> Option<runner::Runner> {
+        for runner in &self.runners {
+            match (runner_type, runner) {
+                (runner_type::RunnerType::Make, runner::Runner::MakeCommand(_)) => {
+                    return Some(runner.clone());
+                }
+                (runner_type::RunnerType::Pnpm, runner::Runner::PnpmCommand(_)) => {
+                    return Some(runner.clone());
+                }
+                _ => continue,
+            }
+        }
+        None
+    }
+
     #[cfg(test)]
     fn init_histories(history_commands: Vec<histories::HistoryCommand>) -> Histories {
+        use std::path::Path;
+
         let mut commands: Vec<histories::HistoryCommand> = Vec::new();
 
         for h in history_commands {
@@ -639,20 +660,26 @@ impl SelectTargetState<'_> {
             runners: vec![runner::Runner::MakeCommand(Make::new_for_test())],
             search_text_area: TextArea_(TextArea::default()),
             targets_list_state: ListState::with_selected(ListState::default(), Some(0)),
-            histories: SelectTargetState::init_histories(vec![
-                histories::HistoryCommand {
-                    runner_type: runner_type::RunnerType::Make,
-                    name: "history0".to_string(),
-                },
-                histories::HistoryCommand {
-                    runner_type: runner_type::RunnerType::Make,
-                    name: "history1".to_string(),
-                },
-                histories::HistoryCommand {
-                    runner_type: runner_type::RunnerType::Make,
-                    name: "history2".to_string(),
-                },
-            ]),
+            // histories: SelectTargetState::init_histories(vec![
+            //     histories::HistoryCommand {
+            //         runner_type: runner_type::RunnerType::Make,
+            //         name: "history0".to_string(),
+            //     },
+            //     histories::HistoryCommand {
+            //         runner_type: runner_type::RunnerType::Make,
+            //         name: "history1".to_string(),
+            //     },
+            //     histories::HistoryCommand {
+            //         runner_type: runner_type::RunnerType::Make,
+            //         name: "history2".to_string(),
+            //     },
+            // ]),
+            histories: vec![command::Command {
+                runner_type: runner_type::RunnerType::Make,
+                name: "history0".to_string(),
+                file_name: todo!(),
+                line_number: todo!(),
+            }],
             histories_list_state: ListState::with_selected(ListState::default(), Some(0)),
         }
     }

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -2,7 +2,7 @@ use crate::{
     file::toml,
     model::{
         command,
-        histories::{self, history_file_path},
+        histories::{self},
         make::Make,
         runner, runner_type,
     },
@@ -24,8 +24,7 @@ use ratatui::{
 use std::{
     collections::HashMap,
     env,
-    fs::File,
-    io::{self, Stderr, Write},
+    io::{self, Stderr},
     panic,
     path::PathBuf,
     process,
@@ -102,13 +101,6 @@ impl Model<'_> {
             break;
         }
 
-        println!("{:?}", result);
-        let mut debug_file = File::create("debug.txt").unwrap();
-        debug_file
-            .write_all(format!("{:?}", result).as_bytes())
-            .unwrap();
-        let _ = debug_file.flush();
-
         result
     }
 
@@ -116,7 +108,6 @@ impl Model<'_> {
         history_commands: Vec<histories::HistoryCommand>,
         runners: &Vec<runner::Runner>,
     ) -> Vec<command::Command> {
-        // なぜかhistoryが表示されないのを修正する
         // TODO: Make this more readable and more performant.
         let mut commands: Vec<command::Command> = Vec::new();
         for history_command in history_commands {
@@ -558,7 +549,7 @@ impl SelectTargetState<'_> {
         // NOTE: self.get_selected_target should be called before self.append_history.
         // Because self.histories_list_state.selected keeps the selected index of the history list
         // before update.
-        if let Some((dir, file_name)) = history_file_path() {
+        if let Some((dir, file_name)) = toml::history_file_path() {
             let all_histories = toml::Histories::get_history().into().append(
                 self.current_dir.clone(),
                 self.histories.clone(),

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -858,32 +858,28 @@ mod test {
                     )),
                 },
             },
-            // TODO(#321): comment in this test
-            // Case {
-            //     title: "ExecuteTarget(History)",
-            //     model: Model {
-            //         app_state: AppState::SelectTarget(SelectTargetState {
-            //             current_pane: CurrentPane::History,
-            //             histories_list_state: ListState::with_selected(
-            //                 ListState::default(),
-            //                 Some(1),
-            //             ),
-            //             ..SelectTargetState::new_for_test()
-            //         }),
-            //     },
-            //     message: Some(Message::ExecuteTarget),
-            //     expect_model: Model {
-            //         app_state: AppState::ExecuteTarget(ExecuteTargetState::new(
-            //             runner::Runner::MakeCommand(Make::new_for_test()),
-            //             command::Command::new(
-            //                 runner_type::RunnerType::Make,
-            //                 "history1".to_string(),
-            //                 PathBuf::new(),
-            //                 4,
-            //             )
-            //         )),
-            //     },
-            // },
+            Case {
+                title: "ExecuteTarget(History)",
+                model: Model {
+                    app_state: AppState::SelectTarget(SelectTargetState {
+                        current_pane: CurrentPane::History,
+                        history_list_state: ListState::with_selected(ListState::default(), Some(1)),
+                        ..SelectTargetState::new_for_test()
+                    }),
+                },
+                message: Some(Message::ExecuteTarget),
+                expect_model: Model {
+                    app_state: AppState::ExecuteTarget(ExecuteTargetState::new(
+                        runner::Runner::MakeCommand(Make::new_for_test()),
+                        command::Command::new(
+                            runner_type::RunnerType::Make,
+                            "history1".to_string(),
+                            PathBuf::from("Makefile"),
+                            4,
+                        ),
+                    )),
+                },
+            },
             Case {
                 title: "Selecting position should be reset if some kind of char
                     was inputted when the target located not in top of the targets",
@@ -982,106 +978,90 @@ mod test {
                     }),
                 },
             },
-            // TODO(#321): comment in this test
-            // Case {
-            //     title: "NextHistory",
-            //     model: Model {
-            //         app_state: AppState::SelectTarget(SelectTargetState {
-            //             current_pane: CurrentPane::History,
-            //             histories_list_state: ListState::with_selected(
-            //                 ListState::default(),
-            //                 Some(0),
-            //             ),
-            //             ..SelectTargetState::new_for_test()
-            //         }),
-            //     },
-            //     message: Some(Message::NextHistory),
-            //     expect_model: Model {
-            //         app_state: AppState::SelectTarget(SelectTargetState {
-            //             current_pane: CurrentPane::History,
-            //             histories_list_state: ListState::with_selected(
-            //                 ListState::default(),
-            //                 Some(1),
-            //             ),
-            //             ..SelectTargetState::new_for_test()
-            //         }),
-            //     },
-            // },
-            // TODO(#321): comment in this test
-            // Case {
-            //     title: "PreviousHistory",
-            //     model: Model {
-            //         app_state: AppState::SelectTarget(SelectTargetState {
-            //             current_pane: CurrentPane::History,
-            //             histories_list_state: ListState::with_selected(
-            //                 ListState::default(),
-            //                 Some(0),
-            //             ),
-            //             ..SelectTargetState::new_for_test()
-            //         }),
-            //     },
-            //     message: Some(Message::NextHistory),
-            //     expect_model: Model {
-            //         app_state: AppState::SelectTarget(SelectTargetState {
-            //             current_pane: CurrentPane::History,
-            //             histories_list_state: ListState::with_selected(
-            //                 ListState::default(),
-            //                 Some(1),
-            //             ),
-            //             ..SelectTargetState::new_for_test()
-            //         }),
-            //     },
-            // },
-            // TODO(#321): comment in this test
-            // Case {
-            //     title: "When the last history is selected and NextHistory is received, it returns to the beginning.",
-            //     model: Model {
-            //         app_state: AppState::SelectTarget(SelectTargetState {
-            //             current_pane: CurrentPane::History,
-            //             histories_list_state: ListState::with_selected(
-            //                 ListState::default(),
-            //                 Some(2),
-            //             ),
-            //             ..SelectTargetState::new_for_test()
-            //         }),
-            //     },
-            //     message: Some(Message::NextHistory),
-            //     expect_model: Model {
-            //         app_state: AppState::SelectTarget(SelectTargetState {
-            //             current_pane: CurrentPane::History,
-            //             histories_list_state: ListState::with_selected(
-            //                 ListState::default(),
-            //                 Some(0),
-            //             ),
-            //             ..SelectTargetState::new_for_test()
-            //         }),
-            //     },
-            // },
-            // TODO(#321): comment in this test
-            // Case {
-            //     title: "When the first history is selected and PreviousHistory is received, it moves to the last history.",
-            //     model: Model {
-            //         app_state: AppState::SelectTarget(SelectTargetState {
-            //             current_pane: CurrentPane::History,
-            //             histories_list_state: ListState::with_selected(
-            //                 ListState::default(),
-            //                 Some(0),
-            //             ),
-            //             ..SelectTargetState::new_for_test()
-            //         }),
-            //     },
-            //     message: Some(Message::PreviousHistory),
-            //     expect_model: Model {
-            //         app_state: AppState::SelectTarget(SelectTargetState {
-            //             current_pane: CurrentPane::History,
-            //             histories_list_state: ListState::with_selected(
-            //                 ListState::default(),
-            //                 Some(2),
-            //             ),
-            //             ..SelectTargetState::new_for_test()
-            //         }),
-            //     },
-            // },
+            Case {
+                title: "NextHistory",
+                model: Model {
+                    app_state: AppState::SelectTarget(SelectTargetState {
+                        current_pane: CurrentPane::History,
+                        history_list_state: ListState::with_selected(ListState::default(), Some(0)),
+                        ..SelectTargetState::new_for_test()
+                    }),
+                },
+                message: Some(Message::NextHistory),
+                expect_model: Model {
+                    app_state: AppState::SelectTarget(SelectTargetState {
+                        current_pane: CurrentPane::History,
+                        history_list_state: ListState::with_selected(ListState::default(), Some(1)),
+                        ..SelectTargetState::new_for_test()
+                    }),
+                },
+            },
+            Case {
+                title: "PreviousHistory",
+                model: Model {
+                    app_state: AppState::SelectTarget(SelectTargetState {
+                        current_pane: CurrentPane::History,
+                        history_list_state: ListState::with_selected(ListState::default(), Some(0)),
+                        ..SelectTargetState::new_for_test()
+                    }),
+                },
+                message: Some(Message::NextHistory),
+                expect_model: Model {
+                    app_state: AppState::SelectTarget(SelectTargetState {
+                        current_pane: CurrentPane::History,
+                        history_list_state: ListState::with_selected(ListState::default(), Some(1)),
+                        ..SelectTargetState::new_for_test()
+                    }),
+                },
+            },
+            Case {
+                title: "When the last history is selected and NextHistory is received, it returns to the beginning.",
+                model: Model {
+                    app_state: AppState::SelectTarget(SelectTargetState {
+                        current_pane: CurrentPane::History,
+                        history_list_state: ListState::with_selected(
+                            ListState::default(),
+                            Some(2),
+                        ),
+                        ..SelectTargetState::new_for_test()
+                    }),
+                },
+                message: Some(Message::NextHistory),
+                expect_model: Model {
+                    app_state: AppState::SelectTarget(SelectTargetState {
+                        current_pane: CurrentPane::History,
+                        history_list_state: ListState::with_selected(
+                            ListState::default(),
+                            Some(0),
+                        ),
+                        ..SelectTargetState::new_for_test()
+                    }),
+                },
+            },
+            Case {
+                title: "When the first history is selected and PreviousHistory is received, it moves to the last history.",
+                model: Model {
+                    app_state: AppState::SelectTarget(SelectTargetState {
+                        current_pane: CurrentPane::History,
+                        history_list_state: ListState::with_selected(
+                            ListState::default(),
+                            Some(0),
+                        ),
+                        ..SelectTargetState::new_for_test()
+                    }),
+                },
+                message: Some(Message::PreviousHistory),
+                expect_model: Model {
+                    app_state: AppState::SelectTarget(SelectTargetState {
+                        current_pane: CurrentPane::History,
+                        history_list_state: ListState::with_selected(
+                            ListState::default(),
+                            Some(2),
+                        ),
+                        ..SelectTargetState::new_for_test()
+                    }),
+                },
+            },
         ];
 
         // NOTE: When running tests, you need to set FZF_MAKE_IS_TESTING=true. Otherwise, the developer's history file will be overwritten.

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -1,3 +1,4 @@
+use super::{config, ui::ui};
 use crate::{
     file::toml,
     model::{
@@ -7,8 +8,6 @@ use crate::{
         runner, runner_type,
     },
 };
-
-use super::{config, ui::ui};
 use anyhow::{anyhow, bail, Result};
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture, KeyCode, KeyEvent},
@@ -30,9 +29,6 @@ use std::{
     process,
 };
 use tui_textarea::TextArea;
-
-// #[cfg(test)]
-// use crate::model::histories::Histories;
 
 // AppState represents the state of the application.
 // "Making impossible states impossible"

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -274,12 +274,10 @@ fn update(model: &mut Model, message: Option<Message>) {
             Some(Message::SearchTextAreaKeyInput(key_event)) => s.handle_key_input(key_event),
             Some(Message::ExecuteTarget) => {
                 if let Some(command) = s.get_selected_target() {
-                    // TODO: make this a method of SelectTargetState
                     s.store_history(command.clone());
-                    // TODO: s.runners[0]ではなくcommand.runner_type を利用する
-                    let executor: runner::Runner = s.runners[0].clone();
-
-                    model.transition_to_execute_target_state(executor, command);
+                    if let Some(r) = command.runner_type.to_runner(&s.runners) {
+                        model.transition_to_execute_target_state(r, command);
+                    }
                 };
             }
             Some(Message::NextTarget) => s.next_target(),

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -578,26 +578,6 @@ impl SelectCommandState<'_> {
     }
 
     #[cfg(test)]
-    // fn init_histories(history_commands: Vec<histories::HistoryCommand>) -> Histories {
-    //     use std::path::Path;
-    //
-    //     let mut commands: Vec<histories::HistoryCommand> = Vec::new();
-    //
-    //     for h in history_commands {
-    //         commands.push(histories::HistoryCommand {
-    //             runner_type: runner_type::RunnerType::Make,
-    //             name: h.name,
-    //         });
-    //     }
-    //
-    //     Histories {
-    //         histories: vec![histories::History {
-    //             path: env::current_dir().unwrap().join(Path::new("Test.mk")),
-    //             commands: commands,
-    //         }],
-    //     }
-    // }
-    #[cfg(test)]
     fn new_for_test() -> Self {
         use crate::model::runner_type;
 

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -347,7 +347,7 @@ impl SelectTargetState<'_> {
             Ok(d) => d,
             Err(e) => bail!("Failed to get current directory: {}", e),
         };
-        let makefile = match Make::create_makefile() {
+        let makefile = match Make::create_makefile(current_dir.clone()) {
             Err(e) => return Err(e),
             Ok(f) => f,
         };

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -539,11 +539,9 @@ impl SelectTargetState<'_> {
         // Because self.histories_list_state.selected keeps the selected index of the history list
         // before update.
         if let Some((dir, file_name)) = toml::history_file_path() {
-            let all_histories = toml::Histories::get_history().into().append(
-                self.current_dir.clone(),
-                self.history.clone(),
-                command,
-            );
+            let all_histories = toml::Histories::get_history()
+                .into()
+                .append(self.current_dir.clone(), command);
 
             // TODO: handle error
             let _ = toml::store_history(dir, file_name, all_histories);

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -543,7 +543,7 @@ impl SelectCommandState<'_> {
                 .append(self.current_dir.clone(), command);
 
             // TODO: handle error
-            let _ = toml::store_history(dir, file_name, all_histories);
+            let _ = toml::create_or_update_history_file(dir, file_name, all_histories);
         };
     }
 

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -306,12 +306,12 @@ pub struct SelectCommandState<'a> {
 
 impl PartialEq for SelectCommandState<'_> {
     fn eq(&self, other: &Self) -> bool {
-        let without_runners = self.current_pane == other.current_pane
+        let other_than_runners = self.current_pane == other.current_pane
             && self.search_text_area == other.search_text_area
             && self.commands_list_state == other.commands_list_state
             && self.history == other.history
             && self.history_list_state == other.history_list_state;
-        if !without_runners {
+        if !other_than_runners {
             return false; // Early return for performance
         }
 

--- a/src/usecase/tui/ui.rs
+++ b/src/usecase/tui/ui.rs
@@ -1,11 +1,5 @@
-use std::{
-    path::PathBuf,
-    sync::{Arc, RwLock},
-};
-
-use crate::model::command;
-
 use super::app::{AppState, CurrentPane, Model, SelectCommandState};
+use crate::model::command;
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use ratatui::{
     layout::{Constraint, Direction, Layout},
@@ -13,6 +7,10 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
     Frame,
+};
+use std::{
+    path::PathBuf,
+    sync::{Arc, RwLock},
 };
 use tui_term::widget::PseudoTerminal;
 

--- a/src/usecase/tui/ui.rs
+++ b/src/usecase/tui/ui.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::model::command;
 
-use super::app::{AppState, CurrentPane, Model, SelectTargetState};
+use super::app::{AppState, CurrentPane, Model, SelectCommandState};
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use ratatui::{
     layout::{Constraint, Direction, Layout},
@@ -17,7 +17,7 @@ use ratatui::{
 use tui_term::widget::PseudoTerminal;
 
 pub fn ui(f: &mut Frame, model: &mut Model) {
-    if let AppState::SelectTarget(model) = &mut model.app_state {
+    if let AppState::SelectCommand(model) = &mut model.app_state {
         let main_and_key_bindings = Layout::default()
             .direction(Direction::Vertical)
             .constraints([Constraint::Min(3), Constraint::Length(1)])
@@ -30,18 +30,18 @@ pub fn ui(f: &mut Frame, model: &mut Model) {
             .split(main_and_key_bindings[0]);
         render_input_block(model, f, main[1]);
 
-        let preview_and_targets = Layout::default()
+        let preview_and_commands = Layout::default()
             .direction(Direction::Vertical)
             .constraints([Constraint::Percentage(70), Constraint::Percentage(30)])
             .split(main[0]);
-        render_preview_block(model, f, preview_and_targets[0]);
+        render_preview_block(model, f, preview_and_commands[0]);
 
-        let targets = Layout::default()
+        let commands = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([Constraint::Percentage(70), Constraint::Percentage(30)])
-            .split(preview_and_targets[1]);
-        render_targets_block(model, f, targets[0]);
-        render_history_block(model, f, targets[1]);
+            .split(preview_and_commands[1]);
+        render_commands_block(model, f, commands[0]);
+        render_history_block(model, f, commands[1]);
     }
 }
 
@@ -64,11 +64,11 @@ fn color_and_border_style_for_selectable(
 }
 
 // Because the setup process of the terminal and render_widget function need to be done in the same scope, the call of the render_widget function is included.
-fn render_preview_block(model: &SelectTargetState, f: &mut Frame, chunk: ratatui::layout::Rect) {
-    let narrow_down_targets = model.narrow_down_targets();
+fn render_preview_block(model: &SelectCommandState, f: &mut Frame, chunk: ratatui::layout::Rect) {
+    let narrow_down_commands = model.narrow_down_commands();
 
     let selecting_command =
-        narrow_down_targets.get(model.commands_list_state.selected().unwrap_or(0));
+        narrow_down_commands.get(model.commands_list_state.selected().unwrap_or(0));
 
     let (fg_color_, border_style) =
         color_and_border_style_for_selectable(model.current_pane.is_main());
@@ -81,7 +81,7 @@ fn render_preview_block(model: &SelectTargetState, f: &mut Frame, chunk: ratatui
         .title(title)
         .title_style(TITLE_STYLE);
 
-    if !model.get_search_area_text().is_empty() && narrow_down_targets.is_empty() {
+    if !model.get_search_area_text().is_empty() && narrow_down_commands.is_empty() {
         f.render_widget(block, chunk);
         return;
     }
@@ -159,15 +159,15 @@ fn preview_command(file_path: PathBuf, line_number: u32) -> CommandBuilder {
     cmd
 }
 
-fn render_targets_block(
-    model: &mut SelectTargetState,
+fn render_commands_block(
+    model: &mut SelectCommandState,
     f: &mut Frame,
     chunk: ratatui::layout::Rect,
 ) {
     f.render_stateful_widget(
-        targets_block(
-            " 📢 Targets ",
-            model.narrow_down_targets(),
+        commands_block(
+            " 📢 Commands ",
+            model.narrow_down_commands(),
             model.current_pane.is_main(),
         ),
         chunk,
@@ -176,7 +176,7 @@ fn render_targets_block(
     );
 }
 
-fn render_input_block(model: &mut SelectTargetState, f: &mut Frame, chunk: ratatui::layout::Rect) {
+fn render_input_block(model: &mut SelectCommandState, f: &mut Frame, chunk: ratatui::layout::Rect) {
     let (fg_color, border_style) =
         color_and_border_style_for_selectable(model.current_pane.is_main());
 
@@ -193,18 +193,18 @@ fn render_input_block(model: &mut SelectTargetState, f: &mut Frame, chunk: ratat
     model
         .search_text_area
         .0
-        .set_placeholder_text("Type text to search target");
+        .set_placeholder_text("Type text to search command");
 
     f.render_widget(&model.search_text_area.0, chunk);
 }
 
 fn render_history_block(
-    model: &mut SelectTargetState,
+    model: &mut SelectCommandState,
     f: &mut Frame,
     chunk: ratatui::layout::Rect,
 ) {
     f.render_stateful_widget(
-        targets_block(
+        commands_block(
             " 📚 History ",
             model.get_history(),
             model.current_pane.is_history(),
@@ -215,13 +215,13 @@ fn render_history_block(
     );
 }
 
-fn render_hint_block(model: &mut SelectTargetState, f: &mut Frame, chunk: ratatui::layout::Rect) {
+fn render_hint_block(model: &mut SelectCommandState, f: &mut Frame, chunk: ratatui::layout::Rect) {
     let hint_text = match model.current_pane {
         CurrentPane::Main => {
-            "Execute the selected target: <enter> | Select target: ↑/↓ | Narrow down target: (type any character) | Move to next tab: <tab> | Quit: <esc>"
+            "Execute the selected command: <enter> | Select command: ↑/↓ | Narrow down command: (type any character) | Move to next tab: <tab> | Quit: <esc>"
         }
         CurrentPane::History => {
-            "Execute the selected target: <enter> | Select target: ↑/↓ | Move to next tab: <tab> | Quit: q/<esc>"
+            "Execute the selected command: <enter> | Select command: ↑/↓ | Move to next tab: <tab> | Quit: q/<esc>"
         }
     };
     let hint = Span::styled(hint_text, Style::default().fg(FG_COLOR_SELECTED));
@@ -232,16 +232,16 @@ fn render_hint_block(model: &mut SelectTargetState, f: &mut Frame, chunk: ratatu
     f.render_widget(key_notes_footer, chunk);
 }
 
-fn targets_block(
+fn commands_block(
     title: &str,
-    narrowed_down_targets: Vec<command::Command>,
+    narrowed_down_commands: Vec<command::Command>,
     is_current: bool,
 ) -> List<'_> {
     let (fg_color, border_style) = color_and_border_style_for_selectable(is_current);
 
-    let list: Vec<ListItem> = narrowed_down_targets
+    let list: Vec<ListItem> = narrowed_down_commands
         .into_iter()
-        .map(|target| ListItem::new(target.to_string()).style(Style::default()))
+        .map(|command| ListItem::new(command.to_string()).style(Style::default()))
         .collect();
 
     List::new(list)

--- a/src/usecase/tui/ui.rs
+++ b/src/usecase/tui/ui.rs
@@ -68,7 +68,7 @@ fn render_preview_block(model: &SelectTargetState, f: &mut Frame, chunk: ratatui
     let narrow_down_targets = model.narrow_down_targets();
 
     let selecting_command =
-        narrow_down_targets.get(model.targets_list_state.selected().unwrap_or(0));
+        narrow_down_targets.get(model.commands_list_state.selected().unwrap_or(0));
 
     let (fg_color_, border_style) =
         color_and_border_style_for_selectable(model.current_pane.is_main());
@@ -172,7 +172,7 @@ fn render_targets_block(
         ),
         chunk,
         // NOTE: It is against TEA's way to update the model value on the UI side, but it is unavoidable so it is allowed.
-        &mut model.targets_list_state,
+        &mut model.commands_list_state,
     );
 }
 
@@ -211,7 +211,7 @@ fn render_history_block(
         ),
         chunk,
         // NOTE: It is against TEA's way to update the model value on the UI side, but it is unavoidable so it is allowed.
-        &mut model.histories_list_state,
+        &mut model.history_list_state,
     );
 }
 


### PR DESCRIPTION
Refactor for #315.
Resolves #323.

## TODO(specification)
- [x] New history file format
- [x]  How to implement `--repeat`  https://github.com/kyu08/fzf-make/blob/788bb4bbede8d7f93291ee568acf57e5a5e95710/src/usecase/repeat.rs#L28
    Just run latest command. New history file format enables it.

## TODO(implementation)
- [x] Read and show history.
- [x] Write the command executed to the history.
- [x] Comment in tests.
- [ ]  ~~When the history file type is the old format(without runner information), rewrite it using the new format immediately.~~ https://github.com/kyu08/fzf-make/issues/326
- [x] Add code comment tells that the the commands are sorted by executed time descending  in the history file.
- [x] Do all TODOs.
- [x] Rename `target` to `command`.

## New history file format

```toml
[[histories]]
path = "path/to/hoge"

[[histories.commands]]
runner = "make"
command = "run"

[[histories.commands]]
runner = "make"
command = "test"

[[histories.commands]]
runner = "pnpm"
command = "install"

[[histories]]
path = "path/to/fuga"

[[histories.commands]]
runner = "yarn"
command = "run"

[[histories.commands]]
runner = "make"
command = "test"

[[histories.commands]]
runner = "bun"
command = "test"
```

<details><summary>A format not adopted</summary>
<p>

```toml
[[histories]]
path = "path/to/hoge"

[[histories.runners]]
name = "make"
commands = ["run", "test"]

[[histories.runners]]
name = "pnpm"
commands = ["install", "test"]

[[histories]]
path = "path/to/fuga"

[[histories.runners]]
name = "make"
commands = ["run", "test"]

[[histories.runners]]
name = "pnpm"
commands = ["install", "test"]


```
</p>
</details> 

<details><summary>Old format</summary>
<p>

```toml
[[history]]
path = "Users/john/projects/projectA/Makefile"
executed-targets = ["test", "lint"]

[[history]]
path = "Users/john/projects/projectB/makefile"
executed-targets = ["test", "lint"]

[[history]]
path = "Users/john/projects/projectC/Makefile"
executed-targets = ["test", "lint"]
```

</p>
</details> 

## TODO(review)
- [x] Check if each responsibility is appropriate.
    - [x] `model/`
    - [x] `tui/`
- [x] Check if test cases is enough.
    - [x] `model/`
    - [x] `tui/`
- [x] Check if naming is appropriate.
    - [x] `model/`
    - [x] `tui/`

