### PR TITLE
Add "Example aliases" to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,6 @@
 [![crates.io](https://img.shields.io/crates/v/fzf-make?style=flatflat-square)](https://crates.io/crates/fzf-make)
 [![Crates.io Total Downloads](https://img.shields.io/crates/d/fzf-make)](https://crates.io/crates/fzf-make)
 
-<p align="center">
-    [English]
-    [<a href="doc/README-de.md">Deutsch</a>]
-    [<a href="doc/README-fr.md">Français</a>]
-</p>
-
 <img src="https://raw.githubusercontent.com/kyu08/fzf-make/main/static/demo.gif" />
 
 </div>
@@ -123,6 +117,28 @@ Within the repo root, execute the following command:
 ```nix
 nix develop
 ```
+
+## Example Aliases
+To simplify the usage of `fzf-make`, you can define aliases in your shell configuration. Below is an example configuration that works for most shells (bash, zsh, fish, etc.):
+
+```sh
+alias fm='fzf-make'
+alias fr='fzf-make repeat'
+alias fh='fzf-make history'
+```
+### Setting Up
+1. Add the above lines to your shell's configuration file:
+* For bash: `~/.bashrc`
+* For zsh: `~/.zshrc`
+* For fish: `~/.config/fish/config.fish` (use alias syntax as shown above)
+1. Reload your shell configuration:
+bash/zsh: `source ~/.bashrc` or `source ~/.zshrc`
+fish: `source ~/.config/fish/config.fish`
+### Example Usage
+* `fm`: Launch fzf-make to select and run a target.
+* `fr`: Repeat the last executed command.
+* `fh`: Open fzf-make with the history pane focused.
+
 
 # 👥 Contribution
 - Contributions are welcome!

--- a/README.md
+++ b/README.md
@@ -103,21 +103,6 @@ Whether `package.json` and `yarn.lock` are in the current directory.
 | `fzf-make --help` / `fzf-make help`                       | Show help                                     |
 | `fzf-make --version` / `fzf-make -v` / `fzf-make version` | Show version                                  |
 
-# 💻 Development
-1. Clone this repository
-1. Change the codes
-1. Run `make run`
-
-To execute test, run `make test`(needs `nextest`).
-
-## nix
-Or you can use `nix` to create a development shell with the project dependencies.
-
-Within the repo root, execute the following command:
-```nix
-nix develop
-```
-
 ## Example Aliases
 To simplify the usage of `fzf-make`, you can define aliases in your shell configuration. Below is an example configuration that works for most shells (bash, zsh, fish, etc.):
 
@@ -139,6 +124,20 @@ fish: `source ~/.config/fish/config.fish`
 * `fr`: Repeat the last executed command.
 * `fh`: Open fzf-make with the history pane focused.
 
+# 💻 Development
+1. Clone this repository
+1. Change the codes
+1. Run `make run`
+
+To execute test, run `make test`(needs `nextest`).
+
+## nix
+Or you can use `nix` to create a development shell with the project dependencies.
+
+Within the repo root, execute the following command:
+```nix
+nix develop
+```
 
 # 👥 Contribution
 - Contributions are welcome!

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 [![crates.io](https://img.shields.io/crates/v/fzf-make?style=flatflat-square)](https://crates.io/crates/fzf-make)
 [![Crates.io Total Downloads](https://img.shields.io/crates/d/fzf-make)](https://crates.io/crates/fzf-make)
 
+<p align="center">
+    [English]
+    [<a href="doc/README-de.md">Deutsch</a>]
+    [<a href="doc/README-fr.md">Français</a>]
+</p>
+
 <img src="https://raw.githubusercontent.com/kyu08/fzf-make/main/static/demo.gif" />
 
 </div>
@@ -111,18 +117,6 @@ alias fm='fzf-make'
 alias fr='fzf-make repeat'
 alias fh='fzf-make history'
 ```
-### Setting Up
-1. Add the above lines to your shell's configuration file:
-* For bash: `~/.bashrc`
-* For zsh: `~/.zshrc`
-* For fish: `~/.config/fish/config.fish` (use alias syntax as shown above)
-1. Reload your shell configuration:
-bash/zsh: `source ~/.bashrc` or `source ~/.zshrc`
-fish: `source ~/.config/fish/config.fish`
-### Example Usage
-* `fm`: Launch fzf-make to select and run a target.
-* `fr`: Repeat the last executed command.
-* `fh`: Open fzf-make with the history pane focused.
 
 # 💻 Development
 1. Clone this repository


### PR DESCRIPTION
Resolves #301 

* Added a section for `Example aliases` in the README.
* Removed paths to non-English versions of README.md and retained only the English version.
