### PR TITLE
fix(ui): use trishume/syntect to highligh files instead of using bat with tui-term

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -912,32 +912,6 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ================================================================
 
-a-kenji/tui-term
-https://github.com/a-kenji/tui-term
-----------------------------------------------------------------
-MIT License
-
-Copyright (c) 2023 a-kenji
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-================================================================
-
 ratatui-org/ratatui
 https://github.com/ratatui-org/ratatui/blob/main/LICENSE
 ----------------------------------------------------------------
@@ -1435,3 +1409,56 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+================================================================
+
+trishume/syntect
+https://github.com/trishume/syntect
+----------------------------------------------------------------
+MIT License
+
+Copyright (c) 2017 Tristan Hume, Keith Hall, Google Inc and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+================================================================
+
+chanq-io/syntect-tui
+https://github.com/chanq-io/syntect-tui
+----------------------------------------------------------------
+MIT License
+
+Copyright (c) 2022 Pierre Chanquion
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+================================================================

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +249,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "custom_error"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f8a51dd197fa6ba5b4dc98a990a43cc13693c23eb0089ebb0fcc1f04152bca6"
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -458,6 +482,8 @@ dependencies = [
  "serde",
  "serde_json",
  "simple-home-dir",
+ "syntect",
+ "syntect-tui",
  "tokio",
  "toml",
  "tui-term",
@@ -715,6 +741,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,6 +847,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "object"
 version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,6 +866,28 @@ name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "onig"
+version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "option-ext"
@@ -883,6 +943,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "plist"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "portable-pty"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,6 +983,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +1005,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1149,6 +1243,15 @@ name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1422,6 +1525,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "syntect"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
+dependencies = [
+ "bincode",
+ "bitflags 1.3.2",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
+name = "syntect-tui"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c2afc700244b6c4bf222c49a9d38f416db12760ee918fe3386a6f1b50f3a56"
+dependencies = [
+ "custom_error",
+ "ratatui",
+ "syntect",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,6 +1624,37 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1792,6 +1959,16 @@ checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
 dependencies = [
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2106,6 +2283,15 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,5 @@ serde_json = "1.0.133"
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread"] }
 update-informer = { version = "1.1", default-features = true, features = ["github"] }
 futures = "0.3"
+syntect-tui = "3.0.5"
+syntect = "5.2.0"

--- a/Makefile
+++ b/Makefile
@@ -33,14 +33,15 @@ tool-spell-check:
 test-ci:
 	RUST_BACKTRACE=full FZF_MAKE_IS_TESTING=true cargo test
 
+TEST_HISTORY_DIR = ./test_data/history
 .PHONY: test
 test: tool-test
-	rm -rf $(TEST_DIR)
+	rm -rf $(TEST_HISTORY_DIR)
 	RUST_BACKTRACE=full FZF_MAKE_IS_TESTING=true cargo nextest run
 
 .PHONY: test-watch
 test-watch: tool-test
-	rm -rf $(TEST_DIR)
+	rm -rf $(TEST_HISTORY_DIR)
 	RUST_BACKTRACE=full FZF_MAKE_IS_TESTING=true cargo watch -x "nextest run"
 
 .PHONY: bump-fzf-make-version
@@ -62,7 +63,7 @@ spell-check: tool-spell-check
 	typos
 
 DEBUG_EXECUTABLE = ./target/debug/fzf-make
-TEST_DIR = ./test_data/history
+TEST_DIR = ./test_data
 .PHONY: run-in-test-data
 run-in-test-data: build
 	@TARGET_DIR=$$(find $(TEST_DIR) -type d -maxdepth 1 | fzf) && \

--- a/README.md
+++ b/README.md
@@ -29,15 +29,9 @@
 - [yarn] Support workspace(collect all scripts which is defined in `workspaces` field in root `package.json`.)
 - **(Scheduled to be developed)** Support config file
 
-# 👓 Prerequisites
-- **(If you install fzf-make via a package manager other than Homebrew)** [bat](https://github.com/sharkdp/bat)
-    - In the future, we intend to make it work with `cat` as well, but currently it only works with `bat`.
-
 # 📦 Installation
 ## macOS
 ### Homebrew
-You don't need to install `bat` because `fzf-make` will install it automatically via Homebrew.
-
 ```sh
 # install
 brew install fzf-make

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
             nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
             postInstall =
               let
-                runtimeDeps = with pkgs; [ bat gnugrep gnumake ];
+                runtimeDeps = with pkgs; [ gnugrep gnumake ];
               in
               ''
                 wrapProgram $out/bin/fzf-make \

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -602,10 +602,6 @@ impl SelectCommandState<'_> {
         self.commands_list_state.select(Some(0));
     }
 
-    pub fn get_search_area_text(&self) -> String {
-        self.search_text_area.0.lines().join("")
-    }
-
     pub fn get_latest_command(&self) -> Option<&command::Command> {
         self.history.first()
     }

--- a/src/usecase/tui/ui.rs
+++ b/src/usecase/tui/ui.rs
@@ -98,8 +98,7 @@ fn render_preview_block2(model: &SelectCommandState, f: &mut Frame, chunk: ratat
         if let Some(_command) = selecting_command {
             let ps = SyntaxSet::load_defaults_newlines();
             let ts = ThemeSet::load_defaults();
-
-            // NOTE: いったんrsで指定してもMakefileやjsonのハイライトはできているのでこれでいく
+            // NOTE: extension is `rs` intentionally because it highlights `Makefile` and `json` files in a good way.(No unnecessary background color)
             let syntax = ps.find_syntax_by_extension("rs").unwrap();
             let theme = &mut ts.themes["base16-ocean.dark"].clone();
 
@@ -126,6 +125,7 @@ fn render_preview_block2(model: &SelectCommandState, f: &mut Frame, chunk: ratat
                     .filter_map(|segment| into_span(segment).ok())
                     .collect();
 
+                // add row number
                 spans.insert(
                     0,
                     Span::styled(format!("{:5} ", start_index + index + 1), Style::default()),

--- a/src/usecase/tui/ui.rs
+++ b/src/usecase/tui/ui.rs
@@ -74,8 +74,6 @@ fn color_and_border_style_for_selectable(
 }
 
 fn render_preview_block(model: &SelectCommandState, f: &mut Frame, chunk: ratatui::layout::Rect) {
-    // NOTE: chunk.rows().count() includes border lines
-    let row_count = chunk.rows().count() - 2;
     let narrow_down_commands = model.narrow_down_commands();
     let selecting_command =
         narrow_down_commands.get(model.commands_list_state.selected().unwrap_or(0));
@@ -85,8 +83,10 @@ fn render_preview_block(model: &SelectCommandState, f: &mut Frame, chunk: ratatu
         _ => None,
     };
     let command_row_index = selecting_command.map(|c| c.line_number as usize - 1);
+    let row_count = chunk.rows().count() - 2; // NOTE: chunk.rows().count() includes border lines
     let start_index_and_end_index =
         command_row_index.map(|c| determine_rendering_position(row_count, c));
+    // NOTE: due to lifetime, source_lines need to be declared outside of `let lines = {/* ... */}`
     let source_lines: Vec<_> = match (selecting_command, start_index_and_end_index, reader) {
         (Some(_), Some((start_index, end_index)), Some(reader)) => {
             reader

--- a/src/usecase/tui/ui.rs
+++ b/src/usecase/tui/ui.rs
@@ -207,12 +207,12 @@ fn render_preview_block2(model: &SelectCommandState, f: &mut Frame, chunk: ratat
                     g: 49,
                     b: 49,
                     // To get bg same as ratatui's background, make this transparent.
-                    a: if index == command.line_number as usize {
-                        15
-                    } else {
-                        0
-                    },
+                    a: if index == 0_usize { 70 } else { 0 },
                 });
+                // データではなく表示が悪いことまでわかったのでそっちの方面でデバッグする
+                // if command.args == "test" {
+                //     panic!("{:?}", source_lines);
+                // }
                 let mut h = HighlightLines::new(syntax, theme);
                 // LinesWithEndings enables use of newlines mode
                 let spans: Vec<Span> = h
@@ -243,6 +243,7 @@ fn render_preview_block2(model: &SelectCommandState, f: &mut Frame, chunk: ratat
     let preview_widget = Paragraph::new(lines)
         .wrap(Wrap { trim: false })
         .block(block);
+    f.render_widget(Clear, chunk);
     f.render_widget(preview_widget, chunk);
 }
 

--- a/src/usecase/tui/ui.rs
+++ b/src/usecase/tui/ui.rs
@@ -44,7 +44,7 @@ pub fn ui(f: &mut Frame, model: &mut Model) {
             .direction(Direction::Vertical)
             .constraints([Constraint::Percentage(70), Constraint::Percentage(30)])
             .split(main[0]);
-        render_preview_block2(model, f, preview_and_commands[0]);
+        render_preview_block(model, f, preview_and_commands[0]);
 
         let commands = Layout::default()
             .direction(Direction::Horizontal)
@@ -73,7 +73,7 @@ fn color_and_border_style_for_selectable(
     }
 }
 
-fn render_preview_block2(model: &SelectCommandState, f: &mut Frame, chunk: ratatui::layout::Rect) {
+fn render_preview_block(model: &SelectCommandState, f: &mut Frame, chunk: ratatui::layout::Rect) {
     // NOTE: chunk.rows().count() includes border lines
     let row_count = chunk.rows().count() - 2;
     let narrow_down_commands = model.narrow_down_commands();
@@ -94,6 +94,7 @@ fn render_preview_block2(model: &SelectCommandState, f: &mut Frame, chunk: ratat
         // HACK: workaround for https://github.com/ratatui/ratatui/issues/876
         .map(|line| line.unwrap().replace("\t", "    "))
         .collect();
+
     let lines = {
         if let Some(_command) = selecting_command {
             let ps = SyntaxSet::load_defaults_newlines();
@@ -105,12 +106,10 @@ fn render_preview_block2(model: &SelectCommandState, f: &mut Frame, chunk: ratat
             let mut lines = vec![];
             for (index, line) in source_lines.iter().enumerate() {
                 theme.settings.background = Some(SColor {
-                    // 0 100 200
-                    // 94 129 172
                     r: 94,
                     g: 120,
                     b: 200,
-                    // To get bg same as ratatui's background, make this transparent.
+                    // To get bg same as ratatui's background, make the line other than includes command transparent.
                     a: if (start_index + index) == command_row_index {
                         50
                     } else {


### PR DESCRIPTION
Resolves #234, resolves #124, resolves #144, resolves #49

## TODO
- [x] test
- [x] update readme
- [x] Update `CREDITS`
	- [x] add syntect
	- [x] add syntect-tui
	- [x] remove tui-term
- [ ] Update brew script: remove dependency to `bat`

## A bug caused by handling of tab characters
When the preview file includes tab characters, rendering crashes.

![Kapture 2024-12-21 at 00 07 55](https://github.com/user-attachments/assets/99baca92-87ed-47ce-be2b-2c3afb9f40c9)

issue: https://github.com/ratatui/ratatui/issues/876

### How I solved
Just replaced `"\t"` with `"    "`.
```rs
    let source_lines: Vec<_> = reader
        .lines()
        .skip(start - 1)
        .take(end - start + 1)
        .map(|line| line.unwrap().replace("\t", "    "))
        .collect();
```

![Kapture 2024-12-21 at 01 53 23](https://github.com/user-attachments/assets/905952c2-603d-4a69-8ba1-23f87cf91891)
