### PR TITLE
fix(cd): specify tree-sitter-just's the version instead of commit hash in `cargo.toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1917,8 +1917,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-just"
-version = "0.0.1"
-source = "git+https://github.com/IndianBoy42/tree-sitter-just.git?rev=f6d2930#f6d29300f9fee15dcd8c2b25ab762001d38da731"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c38f42f5d9d30dec8057f2dd5dca66e2ed3d93aa38371c6ffe5eb8db067aa15"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,5 @@ syntect-tui = "3.0.5"
 syntect = "5.2.0"
 tempfile = "3.14.0"
 tree-sitter = "=0.24.4"
-# FIXME: https://github.com/kyu08/fzf-make/issues/410
-# The latest tag is 0.1.0 and it is old now. So, I am using the latest commit hash.
-tree-sitter-just = { git = "https://github.com/IndianBoy42/tree-sitter-just.git", rev = "f6d2930" }
+tree-sitter-just = "=0.1.0"
 rust-embed = "8.5.0"


### PR DESCRIPTION
Resolves #410

<!--

If you want to add a new runner, please follow the checklist below.

## TODO(add_runner)
- [ ] Add a runner implementation
- [ ] Test to parse history file
- [ ] Test to write to history file
- [ ] Update README.md
- [ ] Update repository description
- [ ] Update the output of `fzf-make --help`
- [ ] Update `CREDITS` if needed
- [ ] Add a test directory to `test_data`

-->
