### PR TITLE
feat(command): support passing additional arguments to the command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - Execute the last executed command(By running `fzf-make --repeat`.)
 - Command history
 - Support [**make**](https://www.gnu.org/software/make/), [**pnpm**](https://github.com/pnpm/pnpm), [**yarn**](https://github.com/yarnpkg/berry), [**just**](https://github.com/casey/just). **Scheduled to be developed: npm.** 
+- Support passing additional arguments to the command using popup window. The UI looks like: https://github.com/kyu08/fzf-make/pull/447
 - [make] Support `include` directive
 - [pnpm] Support workspace(collect scripts all of `package.json` in the directory where fzf-make is launched.)
 - [yarn] Support workspace(collect all scripts which is defined in `workspaces` field in root `package.json`.)

--- a/docs/MANUAL_TEST_CASES.md
+++ b/docs/MANUAL_TEST_CASES.md
@@ -1,7 +1,7 @@
 ## Test cases
 - [ ] `fzf-make`
     - [ ] Execution
-        - [ ] A command name  executing is shown
+        - [ ] A command name executing is shown
         - [ ] Selected command is executed
     - [ ] Narrowing down
         - [ ] Placeholder is shown when no characters are typed.

--- a/src/file/toml.rs
+++ b/src/file/toml.rs
@@ -44,6 +44,7 @@ impl Histories {
         Self { histories }
     }
 
+    // TODO: impl as From trait
     fn from(histories: histories::Histories) -> Self {
         let mut result: Vec<History> = vec![];
         for h in histories.histories {
@@ -68,6 +69,7 @@ pub struct History {
 }
 
 impl History {
+    // TODO: impl as From trait
     fn from(history: histories::History) -> Self {
         let mut commands: Vec<HistoryCommand> = vec![];
         for h in history.commands {
@@ -110,6 +112,7 @@ impl HistoryCommand {
         Self { runner_type, args }
     }
 
+    // TODO: impl as From trait
     fn from(command: histories::HistoryCommand) -> Self {
         Self {
             runner_type: command.runner_type,

--- a/src/model/command.rs
+++ b/src/model/command.rs
@@ -1,4 +1,4 @@
-use super::runner_type;
+use super::{histories, runner_type};
 use std::{fmt, path::PathBuf};
 
 #[derive(PartialEq, Clone, Debug)]
@@ -21,6 +21,36 @@ impl Command {
 }
 
 impl fmt::Display for Command {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} {}", self.runner_type, self.args)
+    }
+}
+
+#[derive(PartialEq, Clone, Debug)]
+pub struct CommandForExec {
+    pub runner_type: runner_type::RunnerType,
+    pub args: String,
+}
+
+impl From<Command> for CommandForExec {
+    fn from(c: Command) -> CommandForExec {
+        CommandForExec {
+            runner_type: c.runner_type.clone(),
+            args: c.args.clone(),
+        }
+    }
+}
+
+impl From<histories::HistoryCommand> for CommandForExec {
+    fn from(c: histories::HistoryCommand) -> CommandForExec {
+        CommandForExec {
+            runner_type: c.runner_type.clone(),
+            args: c.args.clone(),
+        }
+    }
+}
+
+impl fmt::Display for CommandForExec {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} {}", self.runner_type, self.args)
     }

--- a/src/model/command.rs
+++ b/src/model/command.rs
@@ -2,14 +2,14 @@ use super::{histories, runner_type};
 use std::{fmt, path::PathBuf};
 
 #[derive(PartialEq, Clone, Debug)]
-pub struct Command {
+pub struct CommandWithPreview {
     pub runner_type: runner_type::RunnerType,
     pub args: String,
     pub file_path: PathBuf,
     pub line_number: u32,
 }
 
-impl Command {
+impl CommandWithPreview {
     pub fn new(runner_type: runner_type::RunnerType, args: String, file_path: PathBuf, line_number: u32) -> Self {
         Self {
             runner_type,
@@ -20,7 +20,7 @@ impl Command {
     }
 }
 
-impl fmt::Display for Command {
+impl fmt::Display for CommandWithPreview {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} {}", self.runner_type, self.args)
     }
@@ -32,8 +32,8 @@ pub struct CommandForExec {
     pub args: String,
 }
 
-impl From<Command> for CommandForExec {
-    fn from(c: Command) -> CommandForExec {
+impl From<CommandWithPreview> for CommandForExec {
+    fn from(c: CommandWithPreview) -> CommandForExec {
         CommandForExec {
             runner_type: c.runner_type.clone(),
             args: c.args.clone(),

--- a/src/model/histories.rs
+++ b/src/model/histories.rs
@@ -10,7 +10,7 @@ pub struct Histories {
 }
 
 impl Histories {
-    pub fn append(&self, current_dir: PathBuf, command: command::Command) -> Self {
+    pub fn append(&self, current_dir: PathBuf, command: command::CommandForExec) -> Self {
         // Update the command history for the current directory.
         let new_history = {
             match self.histories.iter().find(|h| h.path == current_dir) {
@@ -48,7 +48,7 @@ pub struct History {
 }
 
 impl History {
-    fn append(&self, executed_command: command::Command) -> Self {
+    fn append(&self, executed_command: command::CommandForExec) -> Self {
         let mut updated_commands = self.commands.clone();
         // removes the executed_command from the history
         updated_commands.retain(|t| *t != HistoryCommand::from(executed_command.clone()));
@@ -76,8 +76,8 @@ pub struct HistoryCommand {
     pub args: String,
 }
 
-impl HistoryCommand {
-    pub fn from(command: command::Command) -> Self {
+impl From<command::CommandForExec> for HistoryCommand {
+    fn from(command: command::CommandForExec) -> Self {
         Self {
             runner_type: command.runner_type,
             args: command.args,
@@ -96,7 +96,7 @@ mod test {
         struct Case {
             title: &'static str,
             before: Histories,
-            command_to_append: command::Command,
+            command_to_append: command::CommandForExec,
             after: Histories,
         }
 
@@ -124,11 +124,9 @@ mod test {
                         },
                     ],
                 },
-                command_to_append: command::Command {
+                command_to_append: command::CommandForExec {
                     runner_type: runner_type::RunnerType::Make,
                     args: "append".to_string(),
-                    file_path: PathBuf::from("Makefile"),
-                    line_number: 1,
                 },
                 after: Histories {
                     histories: vec![
@@ -166,11 +164,9 @@ mod test {
                         }],
                     }],
                 },
-                command_to_append: command::Command {
+                command_to_append: command::CommandForExec {
                     runner_type: runner_type::RunnerType::Make,
                     args: "append".to_string(),
-                    file_path: PathBuf::from("Makefile"),
-                    line_number: 1,
                 },
                 after: Histories {
                     histories: vec![
@@ -208,7 +204,7 @@ mod test {
         struct Case {
             title: &'static str,
             before: History,
-            command_to_append: command::Command,
+            command_to_append: command::CommandForExec,
             after: History,
         }
         let path = PathBuf::from("/Users/user/code/fzf-make".to_string());
@@ -228,12 +224,10 @@ mod test {
                         },
                     ],
                 },
-                command_to_append: command::Command::new(
-                    runner_type::RunnerType::Make,
-                    "history2".to_string(),
-                    PathBuf::from("Makefile"),
-                    1,
-                ),
+                command_to_append: command::CommandForExec {
+                    runner_type: runner_type::RunnerType::Make,
+                    args: "history2".to_string(),
+                },
                 after: History {
                     path: path.clone(),
                     commands: vec![
@@ -258,12 +252,10 @@ mod test {
                     path: path.clone(),
                     commands: vec![],
                 },
-                command_to_append: command::Command::new(
-                    runner_type::RunnerType::Make,
-                    "history0".to_string(),
-                    PathBuf::from("Makefile"),
-                    4,
-                ),
+                command_to_append: command::CommandForExec {
+                    runner_type: runner_type::RunnerType::Make,
+                    args: "history0".to_string(),
+                },
                 after: History {
                     path: path.clone(),
                     commands: vec![HistoryCommand {
@@ -291,12 +283,10 @@ mod test {
                         },
                     ],
                 },
-                command_to_append: command::Command::new(
-                    runner_type::RunnerType::Make,
-                    "history2".to_string(),
-                    PathBuf::from("Makefile"),
-                    1,
-                ),
+                command_to_append: command::CommandForExec {
+                    runner_type: runner_type::RunnerType::Make,
+                    args: "history2".to_string(),
+                },
                 after: History {
                     path: path.clone(),
                     commands: vec![
@@ -362,12 +352,10 @@ mod test {
                         },
                     ],
                 },
-                command_to_append: command::Command::new(
-                    runner_type::RunnerType::Make,
-                    "history10".to_string(),
-                    PathBuf::from("Makefile"),
-                    1,
-                ),
+                command_to_append: command::CommandForExec {
+                    runner_type: runner_type::RunnerType::Make,
+                    args: "history10".to_string(),
+                },
                 after: History {
                     path: path.clone(),
                     commands: vec![

--- a/src/model/js_package_manager/js_package_manager_main.rs
+++ b/src/model/js_package_manager/js_package_manager_main.rs
@@ -24,7 +24,7 @@ impl JsPackageManager {
         }
     }
 
-    pub fn to_commands(&self) -> Vec<command::Command> {
+    pub fn to_commands(&self) -> Vec<command::CommandWithPreview> {
         match self {
             JsPackageManager::JsPnpm(pnpm) => pnpm.to_commands(),
             JsPackageManager::JsYarn(yarn) => yarn.to_commands(),

--- a/src/model/js_package_manager/js_package_manager_main.rs
+++ b/src/model/js_package_manager/js_package_manager_main.rs
@@ -17,7 +17,7 @@ pub enum JsPackageManager {
 }
 
 impl JsPackageManager {
-    pub fn command_to_run(&self, command: &command::Command) -> Result<String> {
+    pub fn command_to_run(&self, command: &command::CommandForExec) -> Result<String> {
         match self {
             JsPackageManager::JsPnpm(pnpm) => pnpm.command_to_run(command),
             JsPackageManager::JsYarn(yarn) => yarn.command_to_run(command),
@@ -31,7 +31,7 @@ impl JsPackageManager {
         }
     }
 
-    pub fn execute(&self, command: &command::Command) -> Result<()> {
+    pub fn execute(&self, command: &command::CommandForExec) -> Result<()> {
         match self {
             JsPackageManager::JsPnpm(pnpm) => pnpm.execute(command),
             JsPackageManager::JsYarn(yarn) => yarn.execute(command),

--- a/src/model/js_package_manager/pnpm.rs
+++ b/src/model/js_package_manager/pnpm.rs
@@ -16,22 +16,10 @@ pub struct Pnpm {
 
 impl Pnpm {
     pub fn command_to_run(&self, command: &command::Command) -> Result<String> {
-        // To ensure that the command exists, it is necessary to check the command name.
-        // If implementation is wrong, developers can notice it here.
-        let command = match self.get_command(command.clone()) {
-            Some(c) => c,
-            None => return Err(anyhow!("command not found")),
-        };
-
         Ok(format!("pnpm {}", command.args))
     }
 
     pub fn execute(&self, command: &command::Command) -> Result<()> {
-        let command = match self.get_command(command.clone()) {
-            Some(c) => c,
-            None => return Err(anyhow!("command not found")),
-        };
-
         let child = process::Command::new("pnpm")
             .stdin(process::Stdio::inherit())
             .args(command.args.split_whitespace().collect::<Vec<&str>>())
@@ -160,10 +148,6 @@ impl Pnpm {
 
     pub fn to_commands(&self) -> Vec<command::Command> {
         self.commands.clone()
-    }
-
-    fn get_command(&self, command: command::Command) -> Option<&command::Command> {
-        self.commands.iter().find(|c| **c == command)
     }
 
     // ref: https://pnpm.io/filtering

--- a/src/model/js_package_manager/pnpm.rs
+++ b/src/model/js_package_manager/pnpm.rs
@@ -15,11 +15,11 @@ pub struct Pnpm {
 }
 
 impl Pnpm {
-    pub fn command_to_run(&self, command: &command::Command) -> Result<String> {
+    pub fn command_to_run(&self, command: &command::CommandForExec) -> Result<String> {
         Ok(format!("pnpm {}", command.args))
     }
 
-    pub fn execute(&self, command: &command::Command) -> Result<()> {
+    pub fn execute(&self, command: &command::CommandForExec) -> Result<()> {
         let child = process::Command::new("pnpm")
             .stdin(process::Stdio::inherit())
             .args(command.args.split_whitespace().collect::<Vec<&str>>())

--- a/src/model/js_package_manager/yarn.rs
+++ b/src/model/js_package_manager/yarn.rs
@@ -21,20 +21,10 @@ enum YarnVersion {
 
 impl Yarn {
     pub fn command_to_run(&self, command: &command::Command) -> Result<String> {
-        // To ensure that the command exists, it is necessary to check the command name.
-        // If implementation is wrong, developers can notice it here.
-        match self.get_command(command.clone()) {
-            Some(c) => Ok(format!("yarn {}", c.args)),
-            None => Err(anyhow!("command not found")),
-        }
+        Ok(format!("yarn {}", command.args))
     }
 
     pub fn execute(&self, command: &command::Command) -> Result<()> {
-        let command = match self.get_command(command.clone()) {
-            Some(c) => c,
-            None => return Err(anyhow!("command not found")),
-        };
-
         let child = process::Command::new("yarn")
             .stdin(process::Stdio::inherit())
             .args(command.args.split_whitespace().collect::<Vec<&str>>())
@@ -102,10 +92,6 @@ impl Yarn {
 
     pub fn to_commands(&self) -> Vec<command::Command> {
         self.commands.clone()
-    }
-
-    fn get_command(&self, command: command::Command) -> Option<&command::Command> {
-        self.commands.iter().find(|c| **c == command)
     }
 
     // scripts_to_commands collects all scripts by following steps:

--- a/src/model/js_package_manager/yarn.rs
+++ b/src/model/js_package_manager/yarn.rs
@@ -11,7 +11,7 @@ const YARN_LOCKFILE_NAME: &str = "yarn.lock";
 #[derive(Clone, Debug, PartialEq)]
 pub struct Yarn {
     pub path: PathBuf,
-    commands: Vec<command::Command>,
+    commands: Vec<command::CommandWithPreview>,
 }
 
 enum YarnVersion {
@@ -90,7 +90,7 @@ impl Yarn {
         }
     }
 
-    pub fn to_commands(&self) -> Vec<command::Command> {
+    pub fn to_commands(&self) -> Vec<command::CommandWithPreview> {
         self.commands.clone()
     }
 
@@ -98,7 +98,7 @@ impl Yarn {
     // 1. Collect scripts defined in package.json in the current directory(which fzf-make is launched)
     // 2. Collect the paths of all `package.json` in the workspace.
     // 3. Collect all scripts defined in given `package.json` paths.
-    fn collect_workspace_scripts(current_dir: PathBuf) -> Option<Vec<command::Command>> {
+    fn collect_workspace_scripts(current_dir: PathBuf) -> Option<Vec<command::CommandWithPreview>> {
         // Collect scripts defined in package.json in the current directory(which fzf-make is launched)
         let mut result = Self::collect_scripts_in_package_json(current_dir.clone())?;
 
@@ -115,7 +115,7 @@ impl Yarn {
                 if let Ok(c) = path_to_content::path_to_content(&path) {
                     if let Some((name, parsing_result)) = js::JsPackageManager::parse_package_json(&c) {
                         for (key, _, line_number) in parsing_result {
-                            result.push(command::Command::new(
+                            result.push(command::CommandWithPreview::new(
                                 runner_type::RunnerType::JsPackageManager(runner_type::JsPackageManager::Yarn),
                                 // yarn executes workspace script following format: `yarn workspace {package_name} {script_name}`
                                 // e.g. `yarn workspace app4 build`
@@ -132,7 +132,7 @@ impl Yarn {
         Some(result)
     }
 
-    fn collect_scripts_in_package_json(current_dir: PathBuf) -> Option<Vec<command::Command>> {
+    fn collect_scripts_in_package_json(current_dir: PathBuf) -> Option<Vec<command::CommandWithPreview>> {
         let parsed_scripts_part_of_package_json =
             match path_to_content::path_to_content(&current_dir.join(js::METADATA_FILE_NAME)) {
                 Ok(c) => match js::JsPackageManager::parse_package_json(&c) {
@@ -146,7 +146,7 @@ impl Yarn {
             parsed_scripts_part_of_package_json
                 .iter()
                 .map(|(key, _value, line_number)| {
-                    command::Command::new(
+                    command::CommandWithPreview::new(
                         runner_type::RunnerType::JsPackageManager(runner_type::JsPackageManager::Yarn),
                         key.to_string(),
                         current_dir.clone().join(js::METADATA_FILE_NAME),

--- a/src/model/js_package_manager/yarn.rs
+++ b/src/model/js_package_manager/yarn.rs
@@ -20,11 +20,11 @@ enum YarnVersion {
 }
 
 impl Yarn {
-    pub fn command_to_run(&self, command: &command::Command) -> Result<String> {
+    pub fn command_to_run(&self, command: &command::CommandForExec) -> Result<String> {
         Ok(format!("yarn {}", command.args))
     }
 
-    pub fn execute(&self, command: &command::Command) -> Result<()> {
+    pub fn execute(&self, command: &command::CommandForExec) -> Result<()> {
         let child = process::Command::new("yarn")
             .stdin(process::Stdio::inherit())
             .args(command.args.split_whitespace().collect::<Vec<&str>>())

--- a/src/model/just/just_main.rs
+++ b/src/model/just/just_main.rs
@@ -45,23 +45,13 @@ impl Just {
     }
 
     pub fn command_to_run(&self, command: &command::Command) -> Result<String, anyhow::Error> {
-        let command = match self.get_command(command.clone()) {
-            Some(c) => c,
-            None => return Err(anyhow!("command not found")),
-        };
-
         Ok(format!("just {}", command.args))
     }
 
     pub fn execute(&self, command: &command::Command) -> Result<(), anyhow::Error> {
-        let command = match self.get_command(command.clone()) {
-            Some(c) => c,
-            None => return Err(anyhow!("command not found")),
-        };
-
         let child = process::Command::new("just")
             .stdin(process::Stdio::inherit())
-            .arg(&command.args)
+            .args(command.args.split_whitespace())
             .spawn();
 
         match child {
@@ -71,10 +61,6 @@ impl Just {
             },
             Err(e) => Err(anyhow!("failed to spawn: {}", e)),
         }
-    }
-
-    fn get_command(&self, command: command::Command) -> Option<command::Command> {
-        self.to_commands().iter().find(|c| **c == command).map(|_| command)
     }
 
     fn find_justfile(current_dir: PathBuf) -> Option<PathBuf> {

--- a/src/model/just/just_main.rs
+++ b/src/model/just/just_main.rs
@@ -44,11 +44,11 @@ impl Just {
         self.path.clone()
     }
 
-    pub fn command_to_run(&self, command: &command::Command) -> Result<String, anyhow::Error> {
+    pub fn command_to_run(&self, command: &command::CommandForExec) -> Result<String, anyhow::Error> {
         Ok(format!("just {}", command.args))
     }
 
-    pub fn execute(&self, command: &command::Command) -> Result<(), anyhow::Error> {
+    pub fn execute(&self, command: &command::CommandForExec) -> Result<(), anyhow::Error> {
         let child = process::Command::new("just")
             .stdin(process::Stdio::inherit())
             .args(command.args.split_whitespace())

--- a/src/model/just/just_main.rs
+++ b/src/model/just/just_main.rs
@@ -1,5 +1,5 @@
 use crate::model::{
-    command::{self, Command},
+    command::{self, CommandWithPreview},
     file_util,
     runner_type::RunnerType,
 };
@@ -14,7 +14,7 @@ use tree_sitter::Parser;
 #[derive(Debug, Clone, PartialEq)]
 pub struct Just {
     path: PathBuf,
-    commands: Vec<command::Command>,
+    commands: Vec<command::CommandWithPreview>,
 }
 
 impl Just {
@@ -36,7 +36,7 @@ impl Just {
         })
     }
 
-    pub fn to_commands(&self) -> Vec<command::Command> {
+    pub fn to_commands(&self) -> Vec<command::CommandWithPreview> {
         self.commands.clone()
     }
 
@@ -67,7 +67,7 @@ impl Just {
         file_util::find_file_in_ancestors(current_dir, vec!["justfile", ".justfile"])
     }
 
-    fn parse_justfile(justfile_path: PathBuf, source_code: String) -> Option<Vec<Command>> {
+    fn parse_justfile(justfile_path: PathBuf, source_code: String) -> Option<Vec<CommandWithPreview>> {
         let mut parser = Parser::new();
         parser.set_language(&tree_sitter_just::language()).unwrap();
         let tree = parser.parse(&source_code, None).unwrap();
@@ -111,7 +111,7 @@ impl Just {
                             // So we need to split it by space and take the first element.
                             let command_name = r.split_whitespace().next().unwrap_or("").to_string();
 
-                            commands.push(Command::new(
+                            commands.push(CommandWithPreview::new(
                                 RunnerType::Just,
                                 command_name,
                                 justfile_path.clone(),
@@ -194,7 +194,7 @@ mod test {
         struct Case {
             name: &'static str,
             source_code: &'static str,
-            expected: Option<Vec<Command>>,
+            expected: Option<Vec<CommandWithPreview>>,
         }
         let cases = vec![
             Case {
@@ -233,31 +233,31 @@ clippy:
   echo clippy
         "#,
                 expected: Some(vec![
-                    Command {
+                    CommandWithPreview {
                         runner_type: RunnerType::Just,
                         args: "test".to_string(),
                         file_path: PathBuf::from("justfile"),
                         line_number: 4,
                     },
-                    Command {
+                    CommandWithPreview {
                         runner_type: RunnerType::Just,
                         args: "run".to_string(),
                         file_path: PathBuf::from("justfile"),
                         line_number: 8,
                     },
-                    Command {
+                    CommandWithPreview {
                         runner_type: RunnerType::Just,
                         args: "build".to_string(),
                         file_path: PathBuf::from("justfile"),
                         line_number: 12,
                     },
-                    Command {
+                    CommandWithPreview {
                         runner_type: RunnerType::Just,
                         args: "fmt".to_string(),
                         file_path: PathBuf::from("justfile"),
                         line_number: 16,
                     },
-                    Command {
+                    CommandWithPreview {
                         runner_type: RunnerType::Just,
                         args: "clippy".to_string(),
                         file_path: PathBuf::from("justfile"),
@@ -278,13 +278,13 @@ build:
   echo build
         "#,
                 expected: Some(vec![
-                    Command {
+                    CommandWithPreview {
                         runner_type: RunnerType::Just,
                         args: "run".to_string(),
                         file_path: PathBuf::from("justfile"),
                         line_number: 4,
                     },
-                    Command {
+                    CommandWithPreview {
                         runner_type: RunnerType::Just,
                         args: "build".to_string(),
                         file_path: PathBuf::from("justfile"),

--- a/src/model/make/make_main.rs
+++ b/src/model/make/make_main.rs
@@ -31,8 +31,8 @@ impl Make {
         Make::new_internal(Path::new(&makefile_name).to_path_buf())
     }
 
-    pub fn to_commands(&self) -> Vec<command::Command> {
-        let mut result: Vec<command::Command> = vec![];
+    pub fn to_commands(&self) -> Vec<command::CommandWithPreview> {
+        let mut result: Vec<command::CommandWithPreview> = vec![];
         result.append(&mut self.targets.0.to_vec());
         for include_file in &self.include_files {
             Vec::append(&mut result, &mut include_file.to_commands());
@@ -112,9 +112,9 @@ impl Make {
             path: env::current_dir().unwrap().join(Path::new("Test.mk")),
             include_files: vec![],
             targets: Targets(vec![
-                command::Command::new(runner_type::RunnerType::Make, "target0".to_string(), PathBuf::from(""), 1),
-                command::Command::new(runner_type::RunnerType::Make, "target1".to_string(), PathBuf::from(""), 4),
-                command::Command::new(runner_type::RunnerType::Make, "target2".to_string(), PathBuf::from(""), 7),
+                command::CommandWithPreview::new(runner_type::RunnerType::Make, "target0".to_string(), PathBuf::from(""), 1),
+                command::CommandWithPreview::new(runner_type::RunnerType::Make, "target1".to_string(), PathBuf::from(""), 4),
+                command::CommandWithPreview::new(runner_type::RunnerType::Make, "target2".to_string(), PathBuf::from(""), 7),
             ]),
         }
     }
@@ -233,7 +233,7 @@ mod test {
         struct Case {
             title: &'static str,
             makefile: Make,
-            expect: Vec<command::Command>,
+            expect: Vec<command::CommandWithPreview>,
         }
 
         let cases = vec![
@@ -252,13 +252,13 @@ mod test {
                     path: Path::new("path").to_path_buf(),
                     include_files: vec![],
                     targets: Targets(vec![
-                        command::Command::new(runner_type::RunnerType::Make, "test".to_string(), PathBuf::from(""), 4),
-                        command::Command::new(runner_type::RunnerType::Make, "run".to_string(), PathBuf::from(""), 4),
+                        command::CommandWithPreview::new(runner_type::RunnerType::Make, "test".to_string(), PathBuf::from(""), 4),
+                        command::CommandWithPreview::new(runner_type::RunnerType::Make, "run".to_string(), PathBuf::from(""), 4),
                     ]),
                 },
                 expect: vec![
-                    command::Command::new(runner_type::RunnerType::Make, "test".to_string(), PathBuf::from(""), 4),
-                    command::Command::new(runner_type::RunnerType::Make, "run".to_string(), PathBuf::from(""), 4),
+                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "test".to_string(), PathBuf::from(""), 4),
+                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "run".to_string(), PathBuf::from(""), 4),
                 ],
             },
             Case {
@@ -272,13 +272,13 @@ mod test {
                                 path: Path::new("path2-1").to_path_buf(),
                                 include_files: vec![],
                                 targets: Targets(vec![
-                                    command::Command::new(
+                                    command::CommandWithPreview::new(
                                         runner_type::RunnerType::Make,
                                         "test2-1".to_string(),
                                         PathBuf::from(""),
                                         4,
                                     ),
-                                    command::Command::new(
+                                    command::CommandWithPreview::new(
                                         runner_type::RunnerType::Make,
                                         "run2-1".to_string(),
                                         PathBuf::from(""),
@@ -287,13 +287,13 @@ mod test {
                                 ]),
                             }],
                             targets: Targets(vec![
-                                command::Command::new(
+                                command::CommandWithPreview::new(
                                     runner_type::RunnerType::Make,
                                     "test2".to_string(),
                                     PathBuf::from(""),
                                     4,
                                 ),
-                                command::Command::new(
+                                command::CommandWithPreview::new(
                                     runner_type::RunnerType::Make,
                                     "run2".to_string(),
                                     PathBuf::from(""),
@@ -305,13 +305,13 @@ mod test {
                             path: Path::new("path3").to_path_buf(),
                             include_files: vec![],
                             targets: Targets(vec![
-                                command::Command::new(
+                                command::CommandWithPreview::new(
                                     runner_type::RunnerType::Make,
                                     "test3".to_string(),
                                     PathBuf::from(""),
                                     4,
                                 ),
-                                command::Command::new(
+                                command::CommandWithPreview::new(
                                     runner_type::RunnerType::Make,
                                     "run3".to_string(),
                                     PathBuf::from(""),
@@ -321,19 +321,19 @@ mod test {
                         },
                     ],
                     targets: Targets(vec![
-                        command::Command::new(runner_type::RunnerType::Make, "test1".to_string(), PathBuf::from(""), 4),
-                        command::Command::new(runner_type::RunnerType::Make, "run1".to_string(), PathBuf::from(""), 4),
+                        command::CommandWithPreview::new(runner_type::RunnerType::Make, "test1".to_string(), PathBuf::from(""), 4),
+                        command::CommandWithPreview::new(runner_type::RunnerType::Make, "run1".to_string(), PathBuf::from(""), 4),
                     ]),
                 },
                 expect: vec![
-                    command::Command::new(runner_type::RunnerType::Make, "test1".to_string(), PathBuf::from(""), 4),
-                    command::Command::new(runner_type::RunnerType::Make, "run1".to_string(), PathBuf::from(""), 4),
-                    command::Command::new(runner_type::RunnerType::Make, "test2".to_string(), PathBuf::from(""), 4),
-                    command::Command::new(runner_type::RunnerType::Make, "run2".to_string(), PathBuf::from(""), 4),
-                    command::Command::new(runner_type::RunnerType::Make, "test2-1".to_string(), PathBuf::from(""), 4),
-                    command::Command::new(runner_type::RunnerType::Make, "run2-1".to_string(), PathBuf::from(""), 4),
-                    command::Command::new(runner_type::RunnerType::Make, "test3".to_string(), PathBuf::from(""), 4),
-                    command::Command::new(runner_type::RunnerType::Make, "run3".to_string(), PathBuf::from(""), 4),
+                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "test1".to_string(), PathBuf::from(""), 4),
+                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "run1".to_string(), PathBuf::from(""), 4),
+                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "test2".to_string(), PathBuf::from(""), 4),
+                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "run2".to_string(), PathBuf::from(""), 4),
+                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "test2-1".to_string(), PathBuf::from(""), 4),
+                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "run2-1".to_string(), PathBuf::from(""), 4),
+                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "test3".to_string(), PathBuf::from(""), 4),
+                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "run3".to_string(), PathBuf::from(""), 4),
                 ],
             },
         ];

--- a/src/model/make/make_main.rs
+++ b/src/model/make/make_main.rs
@@ -20,7 +20,7 @@ impl Make {
     /// It is possible to implement this method as an associated function because it takes a
     /// command as an argument. However, if it is an associated function, it can be called
     /// from anywhere, so it is better to make it a method to limit the context.
-    pub fn command_to_run(&self, command: &command::Command) -> Result<String> {
+    pub fn command_to_run(&self, command: &command::CommandForExec) -> Result<String> {
         Ok(format!("make {}", command.args))
     }
 
@@ -41,7 +41,7 @@ impl Make {
         result
     }
 
-    pub fn execute(&self, command: &command::Command) -> Result<()> {
+    pub fn execute(&self, command: &command::CommandForExec) -> Result<()> {
         let child = process::Command::new("make")
             .stdin(process::Stdio::inherit())
             .args(command.args.split_whitespace())

--- a/src/model/make/make_main.rs
+++ b/src/model/make/make_main.rs
@@ -21,13 +21,6 @@ impl Make {
     /// command as an argument. However, if it is an associated function, it can be called
     /// from anywhere, so it is better to make it a method to limit the context.
     pub fn command_to_run(&self, command: &command::Command) -> Result<String> {
-        // To ensure that the command exists, it is necessary to check the command name.
-        // If implementation is wrong, developers can notice it here.
-        let command = match self.get_command(command.clone()) {
-            Some(c) => c,
-            None => return Err(anyhow!("command not found")),
-        };
-
         Ok(format!("make {}", command.args))
     }
 
@@ -49,14 +42,9 @@ impl Make {
     }
 
     pub fn execute(&self, command: &command::Command) -> Result<()> {
-        let command = match self.get_command(command.clone()) {
-            Some(c) => c,
-            None => return Err(anyhow!("command not found")),
-        };
-
         let child = process::Command::new("make")
             .stdin(process::Stdio::inherit())
-            .arg(&command.args)
+            .args(command.args.split_whitespace())
             .spawn();
 
         match child {
@@ -66,10 +54,6 @@ impl Make {
             },
             Err(e) => Err(anyhow!("failed to spawn: {}", e)),
         }
-    }
-
-    fn get_command(&self, command: command::Command) -> Option<command::Command> {
-        self.to_commands().iter().find(|c| **c == command).map(|_| command)
     }
 
     // I gave up writing tests using temp_dir because it was too difficult (it was necessary to change the implementation to some extent).

--- a/src/model/make/make_main.rs
+++ b/src/model/make/make_main.rs
@@ -112,9 +112,24 @@ impl Make {
             path: env::current_dir().unwrap().join(Path::new("Test.mk")),
             include_files: vec![],
             targets: Targets(vec![
-                command::CommandWithPreview::new(runner_type::RunnerType::Make, "target0".to_string(), PathBuf::from(""), 1),
-                command::CommandWithPreview::new(runner_type::RunnerType::Make, "target1".to_string(), PathBuf::from(""), 4),
-                command::CommandWithPreview::new(runner_type::RunnerType::Make, "target2".to_string(), PathBuf::from(""), 7),
+                command::CommandWithPreview::new(
+                    runner_type::RunnerType::Make,
+                    "target0".to_string(),
+                    PathBuf::from(""),
+                    1,
+                ),
+                command::CommandWithPreview::new(
+                    runner_type::RunnerType::Make,
+                    "target1".to_string(),
+                    PathBuf::from(""),
+                    4,
+                ),
+                command::CommandWithPreview::new(
+                    runner_type::RunnerType::Make,
+                    "target2".to_string(),
+                    PathBuf::from(""),
+                    7,
+                ),
             ]),
         }
     }
@@ -252,13 +267,33 @@ mod test {
                     path: Path::new("path").to_path_buf(),
                     include_files: vec![],
                     targets: Targets(vec![
-                        command::CommandWithPreview::new(runner_type::RunnerType::Make, "test".to_string(), PathBuf::from(""), 4),
-                        command::CommandWithPreview::new(runner_type::RunnerType::Make, "run".to_string(), PathBuf::from(""), 4),
+                        command::CommandWithPreview::new(
+                            runner_type::RunnerType::Make,
+                            "test".to_string(),
+                            PathBuf::from(""),
+                            4,
+                        ),
+                        command::CommandWithPreview::new(
+                            runner_type::RunnerType::Make,
+                            "run".to_string(),
+                            PathBuf::from(""),
+                            4,
+                        ),
                     ]),
                 },
                 expect: vec![
-                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "test".to_string(), PathBuf::from(""), 4),
-                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "run".to_string(), PathBuf::from(""), 4),
+                    command::CommandWithPreview::new(
+                        runner_type::RunnerType::Make,
+                        "test".to_string(),
+                        PathBuf::from(""),
+                        4,
+                    ),
+                    command::CommandWithPreview::new(
+                        runner_type::RunnerType::Make,
+                        "run".to_string(),
+                        PathBuf::from(""),
+                        4,
+                    ),
                 ],
             },
             Case {
@@ -321,19 +356,69 @@ mod test {
                         },
                     ],
                     targets: Targets(vec![
-                        command::CommandWithPreview::new(runner_type::RunnerType::Make, "test1".to_string(), PathBuf::from(""), 4),
-                        command::CommandWithPreview::new(runner_type::RunnerType::Make, "run1".to_string(), PathBuf::from(""), 4),
+                        command::CommandWithPreview::new(
+                            runner_type::RunnerType::Make,
+                            "test1".to_string(),
+                            PathBuf::from(""),
+                            4,
+                        ),
+                        command::CommandWithPreview::new(
+                            runner_type::RunnerType::Make,
+                            "run1".to_string(),
+                            PathBuf::from(""),
+                            4,
+                        ),
                     ]),
                 },
                 expect: vec![
-                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "test1".to_string(), PathBuf::from(""), 4),
-                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "run1".to_string(), PathBuf::from(""), 4),
-                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "test2".to_string(), PathBuf::from(""), 4),
-                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "run2".to_string(), PathBuf::from(""), 4),
-                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "test2-1".to_string(), PathBuf::from(""), 4),
-                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "run2-1".to_string(), PathBuf::from(""), 4),
-                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "test3".to_string(), PathBuf::from(""), 4),
-                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "run3".to_string(), PathBuf::from(""), 4),
+                    command::CommandWithPreview::new(
+                        runner_type::RunnerType::Make,
+                        "test1".to_string(),
+                        PathBuf::from(""),
+                        4,
+                    ),
+                    command::CommandWithPreview::new(
+                        runner_type::RunnerType::Make,
+                        "run1".to_string(),
+                        PathBuf::from(""),
+                        4,
+                    ),
+                    command::CommandWithPreview::new(
+                        runner_type::RunnerType::Make,
+                        "test2".to_string(),
+                        PathBuf::from(""),
+                        4,
+                    ),
+                    command::CommandWithPreview::new(
+                        runner_type::RunnerType::Make,
+                        "run2".to_string(),
+                        PathBuf::from(""),
+                        4,
+                    ),
+                    command::CommandWithPreview::new(
+                        runner_type::RunnerType::Make,
+                        "test2-1".to_string(),
+                        PathBuf::from(""),
+                        4,
+                    ),
+                    command::CommandWithPreview::new(
+                        runner_type::RunnerType::Make,
+                        "run2-1".to_string(),
+                        PathBuf::from(""),
+                        4,
+                    ),
+                    command::CommandWithPreview::new(
+                        runner_type::RunnerType::Make,
+                        "test3".to_string(),
+                        PathBuf::from(""),
+                        4,
+                    ),
+                    command::CommandWithPreview::new(
+                        runner_type::RunnerType::Make,
+                        "run3".to_string(),
+                        PathBuf::from(""),
+                        4,
+                    ),
                 ],
             },
         ];

--- a/src/model/make/target.rs
+++ b/src/model/make/target.rs
@@ -3,11 +3,11 @@ use regex::Regex;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct Targets(pub Vec<command::Command>);
+pub struct Targets(pub Vec<command::CommandWithPreview>);
 
 impl Targets {
     pub fn new(content: String, path: PathBuf) -> Targets {
-        let mut result: Vec<command::Command> = Vec::new();
+        let mut result: Vec<command::CommandWithPreview> = Vec::new();
         let mut define_block_depth = 0;
 
         for (i, line) in content.lines().enumerate() {
@@ -22,7 +22,7 @@ impl Targets {
                     if define_block_depth == 0 {
                         if let Some(t) = line_to_target(line.to_string()) {
                             let command =
-                                command::Command::new(runner_type::RunnerType::Make, t, path.clone(), i as u32 + 1);
+                                command::CommandWithPreview::new(runner_type::RunnerType::Make, t, path.clone(), i as u32 + 1);
                             result.push(command);
                         }
                     }
@@ -107,11 +107,11 @@ test: # run test
 echo:
 	@echo good",
                 expect: Targets(vec![
-                    command::Command::new(runner_type::RunnerType::Make, "run".to_string(), PathBuf::from(""), 3),
-                    command::Command::new(runner_type::RunnerType::Make, "build".to_string(), PathBuf::from(""), 6),
-                    command::Command::new(runner_type::RunnerType::Make, "check".to_string(), PathBuf::from(""), 9),
-                    command::Command::new(runner_type::RunnerType::Make, "test".to_string(), PathBuf::from(""), 13),
-                    command::Command::new(runner_type::RunnerType::Make, "echo".to_string(), PathBuf::from(""), 16),
+                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "run".to_string(), PathBuf::from(""), 3),
+                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "build".to_string(), PathBuf::from(""), 6),
+                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "check".to_string(), PathBuf::from(""), 9),
+                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "test".to_string(), PathBuf::from(""), 13),
+                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "echo".to_string(), PathBuf::from(""), 16),
                 ]),
             },
             Case {
@@ -126,8 +126,8 @@ clone:
 build:
 		@cargo build",
                 expect: Targets(vec![
-                    command::Command::new(runner_type::RunnerType::Make, "clone".to_string(), PathBuf::from(""), 4),
-                    command::Command::new(runner_type::RunnerType::Make, "build".to_string(), PathBuf::from(""), 7),
+                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "clone".to_string(), PathBuf::from(""), 4),
+                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "build".to_string(), PathBuf::from(""), 7),
                 ]),
             },
             Case {
@@ -149,8 +149,8 @@ endef
 my_script:
 	$(file >my_script,$(script-block))\n",
                 expect: Targets(vec![
-                    command::Command::new(runner_type::RunnerType::Make, "all".to_string(), PathBuf::from(""), 3),
-                    command::Command::new(runner_type::RunnerType::Make, "my_script".to_string(), PathBuf::from(""), 9),
+                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "all".to_string(), PathBuf::from(""), 3),
+                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "my_script".to_string(), PathBuf::from(""), 9),
                 ]),
             },
             Case {

--- a/src/model/make/target.rs
+++ b/src/model/make/target.rs
@@ -21,8 +21,12 @@ impl Targets {
                 LineType::Normal => {
                     if define_block_depth == 0 {
                         if let Some(t) = line_to_target(line.to_string()) {
-                            let command =
-                                command::CommandWithPreview::new(runner_type::RunnerType::Make, t, path.clone(), i as u32 + 1);
+                            let command = command::CommandWithPreview::new(
+                                runner_type::RunnerType::Make,
+                                t,
+                                path.clone(),
+                                i as u32 + 1,
+                            );
                             result.push(command);
                         }
                     }
@@ -107,11 +111,36 @@ test: # run test
 echo:
 	@echo good",
                 expect: Targets(vec![
-                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "run".to_string(), PathBuf::from(""), 3),
-                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "build".to_string(), PathBuf::from(""), 6),
-                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "check".to_string(), PathBuf::from(""), 9),
-                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "test".to_string(), PathBuf::from(""), 13),
-                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "echo".to_string(), PathBuf::from(""), 16),
+                    command::CommandWithPreview::new(
+                        runner_type::RunnerType::Make,
+                        "run".to_string(),
+                        PathBuf::from(""),
+                        3,
+                    ),
+                    command::CommandWithPreview::new(
+                        runner_type::RunnerType::Make,
+                        "build".to_string(),
+                        PathBuf::from(""),
+                        6,
+                    ),
+                    command::CommandWithPreview::new(
+                        runner_type::RunnerType::Make,
+                        "check".to_string(),
+                        PathBuf::from(""),
+                        9,
+                    ),
+                    command::CommandWithPreview::new(
+                        runner_type::RunnerType::Make,
+                        "test".to_string(),
+                        PathBuf::from(""),
+                        13,
+                    ),
+                    command::CommandWithPreview::new(
+                        runner_type::RunnerType::Make,
+                        "echo".to_string(),
+                        PathBuf::from(""),
+                        16,
+                    ),
                 ]),
             },
             Case {
@@ -126,8 +155,18 @@ clone:
 build:
 		@cargo build",
                 expect: Targets(vec![
-                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "clone".to_string(), PathBuf::from(""), 4),
-                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "build".to_string(), PathBuf::from(""), 7),
+                    command::CommandWithPreview::new(
+                        runner_type::RunnerType::Make,
+                        "clone".to_string(),
+                        PathBuf::from(""),
+                        4,
+                    ),
+                    command::CommandWithPreview::new(
+                        runner_type::RunnerType::Make,
+                        "build".to_string(),
+                        PathBuf::from(""),
+                        7,
+                    ),
                 ]),
             },
             Case {
@@ -149,8 +188,18 @@ endef
 my_script:
 	$(file >my_script,$(script-block))\n",
                 expect: Targets(vec![
-                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "all".to_string(), PathBuf::from(""), 3),
-                    command::CommandWithPreview::new(runner_type::RunnerType::Make, "my_script".to_string(), PathBuf::from(""), 9),
+                    command::CommandWithPreview::new(
+                        runner_type::RunnerType::Make,
+                        "all".to_string(),
+                        PathBuf::from(""),
+                        3,
+                    ),
+                    command::CommandWithPreview::new(
+                        runner_type::RunnerType::Make,
+                        "my_script".to_string(),
+                        PathBuf::from(""),
+                        9,
+                    ),
                 ]),
             },
             Case {

--- a/src/model/runner.rs
+++ b/src/model/runner.rs
@@ -14,7 +14,7 @@ pub enum Runner {
 }
 
 impl Runner {
-    pub fn list_commands(&self) -> Vec<command::Command> {
+    pub fn list_commands(&self) -> Vec<command::CommandWithPreview> {
         match self {
             Runner::MakeCommand(make) => make.to_commands(),
             Runner::JsPackageManager(js) => js.to_commands(),

--- a/src/model/runner.rs
+++ b/src/model/runner.rs
@@ -30,7 +30,7 @@ impl Runner {
         }
     }
 
-    pub fn show_command(&self, command: &command::Command) {
+    pub fn show_command(&self, command: &command::CommandForExec) {
         let command_or_error_message = match self {
             Runner::MakeCommand(make) => make.command_to_run(command),
             Runner::JsPackageManager(js) => js.command_to_run(command),
@@ -45,7 +45,7 @@ impl Runner {
         );
     }
 
-    pub fn execute(&self, command: &command::Command) -> Result<()> {
+    pub fn execute(&self, command: &command::CommandForExec) -> Result<()> {
         match self {
             Runner::MakeCommand(make) => make.execute(command),
             Runner::JsPackageManager(js) => js.execute(command),

--- a/src/model/runner_type.rs
+++ b/src/model/runner_type.rs
@@ -29,6 +29,7 @@ impl RunnerType {
         None
     }
 
+    // TODO: impl as From trait
     pub fn from(runner: &runner::Runner) -> Self {
         match runner {
             runner::Runner::MakeCommand(_) => RunnerType::Make,

--- a/src/usecase/repeat.rs
+++ b/src/usecase/repeat.rs
@@ -2,7 +2,7 @@ use super::tui::{
     app::{AppState, Model},
     config,
 };
-use crate::usecase::usecase_main::Usecase;
+use crate::{model::command, usecase::usecase_main::Usecase};
 use anyhow::{anyhow, Result};
 use futures::{future::BoxFuture, FutureExt};
 
@@ -27,8 +27,8 @@ impl Usecase for Repeat {
                     AppState::SelectCommand(state) => match state.get_latest_command() {
                         Some(c) => match state.get_runner(&c.runner_type) {
                             Some(runner) => {
-                                runner.show_command(c);
-                                runner.execute(c)
+                                runner.show_command(&command::CommandForExec::from(c.clone()));
+                                runner.execute(&command::CommandForExec::from(c.clone()))
                             }
                             None => Err(anyhow!("runner not found.")),
                         },

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -697,7 +697,9 @@ impl<'a> AdditionalWindowState<'a> {
     pub fn append_arguments(&self) -> command::CommandForExec {
         let mut new_command = self.command.clone();
         if let Some(arguments) = self.arguments_text_area.0.lines().join(" ").trim().to_string().into() {
-            new_command.args.push_str(&format!(" {}", arguments));
+            if !arguments.is_empty() {
+                new_command.args.push_str(&format!(" {}", arguments));
+            }
         }
         new_command
     }

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -696,10 +696,9 @@ impl<'a> AdditionalWindowState<'a> {
 
     pub fn append_arguments(&self) -> command::CommandForExec {
         let mut new_command = self.command.clone();
-        if let Some(arguments) = self.arguments_text_area.0.lines().join(" ").trim().to_string().into() {
-            if !arguments.is_empty() {
-                new_command.args.push_str(&format!(" {}", arguments));
-            }
+        let arguments = self.arguments_text_area.0.lines().join(" ").trim().to_string();
+        if !arguments.is_empty() {
+            new_command.args.push_str(&format!(" {}", arguments));
         }
         new_command
     }

--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -409,7 +409,7 @@ impl SelectCommandState<'_> {
         }
     }
 
-    fn selected_command(&self) -> Option<command::Command> {
+    fn selected_command(&self) -> Option<command::CommandWithPreview> {
         match self.commands_list_state.selected() {
             Some(i) => self.narrow_down_commands().get(i).cloned(),
             None => None,
@@ -428,9 +428,9 @@ impl SelectCommandState<'_> {
         }
     }
 
-    pub fn narrow_down_commands(&self) -> Vec<command::Command> {
+    pub fn narrow_down_commands(&self) -> Vec<command::CommandWithPreview> {
         let commands = {
-            let mut commands: Vec<command::Command> = Vec::new();
+            let mut commands: Vec<command::CommandWithPreview> = Vec::new();
             for runner in &self.runners {
                 commands = [commands, runner.list_commands()].concat();
             }
@@ -442,7 +442,7 @@ impl SelectCommandState<'_> {
         }
 
         // Store the commands in a temporary map in the form of map[command.to_string()]Command
-        let mut temporary_command_map: HashMap<String, command::Command> = HashMap::new();
+        let mut temporary_command_map: HashMap<String, command::CommandWithPreview> = HashMap::new();
         for command in &commands {
             temporary_command_map.insert(command.to_string(), command.clone());
         }
@@ -467,7 +467,7 @@ impl SelectCommandState<'_> {
             list.into_iter().map(|(_, command)| command).collect()
         };
 
-        let mut result: Vec<command::Command> = Vec::new();
+        let mut result: Vec<command::CommandWithPreview> = Vec::new();
         // Get the filtered values from the temporary map
         for c in filtered_list {
             if let Some(command) = temporary_command_map.get(&c) {

--- a/src/usecase/tui/ui.rs
+++ b/src/usecase/tui/ui.rs
@@ -338,13 +338,17 @@ fn render_additional_arguments_popup(model: &mut SelectCommandState, f: &mut Fra
 }
 
 fn render_hint_block(model: &mut SelectCommandState, f: &mut Frame, chunk: ratatui::layout::Rect) {
-    let hint_text = match model.current_pane {
+    let hint_text = if model.is_additional_arguments_popup_opened() {
+        "Execute the selected command: <enter> | Passing additional arguments: (type any character) | Close the popup window: <esc>"
+    } else {
+        match model.current_pane {
         CurrentPane::Main => {
             "Execute the selected command: <enter> | Select command: ↑/↓ | Narrow down command: (type any character) | Move to next tab: <tab> | Quit: <esc>"
         }
         CurrentPane::History => {
             "Execute the selected command: <enter> | Select command: ↑/↓ | Move to next tab: <tab> | Quit: q/<esc>"
         }
+    }
     };
     let hint = Span::styled(hint_text, Style::default().fg(FG_COLOR_SELECTED));
 

--- a/src/usecase/tui/ui.rs
+++ b/src/usecase/tui/ui.rs
@@ -2,10 +2,10 @@ use super::app::{AppState, CurrentPane, Model, SelectCommandState};
 use crate::model::command;
 use anyhow::{Context, Result};
 use ratatui::{
-    layout::{Constraint, Direction, Layout},
+    layout::{Constraint, Direction, Flex, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
+    widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap},
     Frame,
 };
 use rust_embed::RustEmbed;
@@ -22,6 +22,14 @@ use syntect::{
 };
 use syntect_tui::into_span;
 
+/// helper function to create a centered rect using up certain percentage of the available rect `r`
+fn popup_area(area: Rect, x: u16, y: u16) -> Rect {
+    let vertical = Layout::vertical([Constraint::Length(y)]).flex(Flex::Center);
+    let horizontal = Layout::horizontal([Constraint::Percentage(x)]).flex(Flex::Center);
+    let [area] = vertical.areas(area);
+    let [area] = horizontal.areas(area);
+    area
+}
 pub fn ui(f: &mut Frame, model: &mut Model) {
     if let AppState::SelectCommand(model) = &mut model.app_state {
         let main_and_key_bindings = Layout::default()
@@ -60,6 +68,9 @@ pub fn ui(f: &mut Frame, model: &mut Model) {
             .split(preview_and_commands[1]);
         render_commands_block(model, f, commands[0]);
         render_history_block(model, f, commands[1]);
+
+        // Render additional arguments popup if needed.
+        render_additional_arguments_popup(model, f);
     }
 }
 
@@ -69,8 +80,11 @@ const BORDER_STYLE_SELECTED: ratatui::widgets::block::BorderType = ratatui::widg
 const BORDER_STYLE_NOT_SELECTED: ratatui::widgets::block::BorderType = ratatui::widgets::BorderType::Plain;
 const TITLE_STYLE: ratatui::style::Style = Style::new().add_modifier(Modifier::BOLD);
 
-fn color_and_border_style_for_selectable(is_selected: bool) -> (Color, ratatui::widgets::block::BorderType) {
-    if is_selected {
+fn color_and_border_style_for_selectable(
+    is_selected: bool,
+    is_additional_arguments_popup_opened: bool,
+) -> (Color, ratatui::widgets::block::BorderType) {
+    if is_selected && !is_additional_arguments_popup_opened {
         (FG_COLOR_SELECTED, BORDER_STYLE_SELECTED)
     } else {
         (FG_COLOR_NOT_SELECTED, BORDER_STYLE_NOT_SELECTED)
@@ -150,7 +164,10 @@ fn render_preview_block(model: &SelectCommandState, f: &mut Frame, chunk: ratatu
         }
     };
 
-    let (fg_color_, border_style) = color_and_border_style_for_selectable(model.current_pane.is_main());
+    let (fg_color_, border_style) = color_and_border_style_for_selectable(
+        model.current_pane.is_main(),
+        model.is_additional_arguments_popup_opened(),
+    );
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(border_style)
@@ -214,7 +231,12 @@ fn determine_rendering_position(row_count: usize, command_row_index: usize) -> (
 
 fn render_commands_block(model: &mut SelectCommandState, f: &mut Frame, chunk: ratatui::layout::Rect) {
     f.render_stateful_widget(
-        commands_block(" 📢 Commands ", model.narrow_down_commands(), model.current_pane.is_main()),
+        commands_block(
+            " 📢 Commands ",
+            model.narrow_down_commands(),
+            model.current_pane.is_main(),
+            model.is_additional_arguments_popup_opened(),
+        ),
         chunk,
         // NOTE: It is against TEA's way to update the model value on the UI side, but it is unavoidable so it is allowed.
         &mut model.commands_list_state,
@@ -222,7 +244,10 @@ fn render_commands_block(model: &mut SelectCommandState, f: &mut Frame, chunk: r
 }
 
 fn render_input_block(model: &mut SelectCommandState, f: &mut Frame, chunk: ratatui::layout::Rect) {
-    let (fg_color, border_style) = color_and_border_style_for_selectable(model.current_pane.is_main());
+    let (fg_color, border_style) = color_and_border_style_for_selectable(
+        model.current_pane.is_main(),
+        model.is_additional_arguments_popup_opened(),
+    );
 
     let block = Block::default()
         .title(" 🔍 Search ")
@@ -278,11 +303,38 @@ fn render_current_version_block(f: &mut Frame, chunk: ratatui::layout::Rect) {
 
 fn render_history_block(model: &mut SelectCommandState, f: &mut Frame, chunk: ratatui::layout::Rect) {
     f.render_stateful_widget(
-        commands_block(" 📚 History ", model.get_history(), model.current_pane.is_history()),
+        commands_block(
+            " 📚 History ",
+            model.get_history(),
+            model.current_pane.is_history(),
+            model.is_additional_arguments_popup_opened(),
+        ),
         chunk,
         // NOTE: It is against TEA's way to update the model value on the UI side, but it is unavoidable so it is allowed.
         &mut model.history_list_state,
     );
+}
+
+fn render_additional_arguments_popup(model: &mut SelectCommandState, f: &mut Frame) {
+    if model.additional_arguments_popup_state.is_none() {
+        return;
+    }
+    // If this popup is going to be opened, model.get_selected_command() returns Some(command).
+    // So we can call unwrap() safely.
+    let command = model.get_selected_command().unwrap();
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BORDER_STYLE_SELECTED)
+        .border_style(Style::default().fg(FG_COLOR_SELECTED))
+        .title(format!("Pass additional arguments to `{}`", command));
+
+    let area = popup_area(f.area(), 60, 3);
+    // This clears out the background which is needed to allow
+    // overdrawing
+    f.render_widget(Clear, area);
+    let mut additional_arguments_popup_statw = model.additional_arguments_popup_state.clone().unwrap();
+    additional_arguments_popup_statw.arguments_text_area.0.set_block(block);
+    f.render_widget(&additional_arguments_popup_statw.arguments_text_area.0, area);
 }
 
 fn render_hint_block(model: &mut SelectCommandState, f: &mut Frame, chunk: ratatui::layout::Rect) {
@@ -302,8 +354,14 @@ fn render_hint_block(model: &mut SelectCommandState, f: &mut Frame, chunk: ratat
     f.render_widget(key_notes_footer, chunk);
 }
 
-fn commands_block(title: &str, narrowed_down_commands: Vec<command::Command>, is_current: bool) -> List<'_> {
-    let (fg_color, border_style) = color_and_border_style_for_selectable(is_current);
+fn commands_block(
+    title: &str,
+    narrowed_down_commands: Vec<command::Command>,
+    is_current: bool,
+    is_additional_arguments_popup_opened: bool,
+) -> List<'_> {
+    let (fg_color, border_style) =
+        color_and_border_style_for_selectable(is_current, is_additional_arguments_popup_opened);
 
     let list: Vec<ListItem> = narrowed_down_commands
         .into_iter()

--- a/src/usecase/tui/ui.rs
+++ b/src/usecase/tui/ui.rs
@@ -233,7 +233,7 @@ fn render_commands_block(model: &mut SelectCommandState, f: &mut Frame, chunk: r
     f.render_stateful_widget(
         commands_block(
             " 📢 Commands ",
-            model.narrow_down_commands(),
+            model.narrow_down_commands().into_iter().map(|c| c.into()).collect(),
             model.current_pane.is_main(),
             model.is_additional_arguments_popup_opened(),
         ),
@@ -305,7 +305,7 @@ fn render_history_block(model: &mut SelectCommandState, f: &mut Frame, chunk: ra
     f.render_stateful_widget(
         commands_block(
             " 📚 History ",
-            model.get_history(),
+            model.get_history().into_iter().map(|c| c.into()).collect(),
             model.current_pane.is_history(),
             model.is_additional_arguments_popup_opened(),
         ),
@@ -332,9 +332,9 @@ fn render_additional_arguments_popup(model: &mut SelectCommandState, f: &mut Fra
     // This clears out the background which is needed to allow
     // overdrawing
     f.render_widget(Clear, area);
-    let mut additional_arguments_popup_statw = model.additional_arguments_popup_state.clone().unwrap();
-    additional_arguments_popup_statw.arguments_text_area.0.set_block(block);
-    f.render_widget(&additional_arguments_popup_statw.arguments_text_area.0, area);
+    let mut additional_arguments_popup_state = model.additional_arguments_popup_state.clone().unwrap();
+    additional_arguments_popup_state.arguments_text_area.0.set_block(block);
+    f.render_widget(&additional_arguments_popup_state.arguments_text_area.0, area);
 }
 
 fn render_hint_block(model: &mut SelectCommandState, f: &mut Frame, chunk: ratatui::layout::Rect) {
@@ -356,7 +356,7 @@ fn render_hint_block(model: &mut SelectCommandState, f: &mut Frame, chunk: ratat
 
 fn commands_block(
     title: &str,
-    narrowed_down_commands: Vec<command::Command>,
+    narrowed_down_commands: Vec<command::CommandForExec>,
     is_current: bool,
     is_additional_arguments_popup_opened: bool,
 ) -> List<'_> {

--- a/test_data/just/justfile
+++ b/test_data/just/justfile
@@ -7,6 +7,9 @@ test:
 run message:
   echo "run {{message}}"
 
+run2 message1 message2:
+  echo "run {{message1}} {{message2}}"
+
 [group: 'misc']
 build:
   echo build

--- a/test_data/just/justfile
+++ b/test_data/just/justfile
@@ -4,8 +4,8 @@ test:
   cargo test --all
 
 [group: 'misc']
-run:
-  echo run
+run message:
+  echo "run {{message}}"
 
 [group: 'misc']
 build:

--- a/test_data/make/Makefile
+++ b/test_data/make/Makefile
@@ -2,6 +2,11 @@
 run:
 	echo "run"
 
+# just echo args
+.PHONY: run-with-args
+run-with-args:
+	echo $(ARG1); echo $(ARG2)
+
 include ./makefiles/test.mk
 
 .PHONY: cmd

--- a/test_data/make/Makefile
+++ b/test_data/make/Makefile
@@ -2,10 +2,13 @@
 run:
 	echo "run"
 
-# just echo args
 .PHONY: run-with-args
 run-with-args:
 	echo $(ARG1); echo $(ARG2)
+
+.PHONY: run-with-arg
+run-with-arg:
+	echo $(ARG1)
 
 include ./makefiles/test.mk
 


### PR DESCRIPTION
Resolves #364 

## What is "passing additional arguments"?
1. Press `Ctrl + O` to open additional arguments popup.
    <img width="1498" alt=" 2025-05-07 at 23 42 02" src="https://github.com/user-attachments/assets/8124433a-bd42-408d-8c21-b768b26b1b58" />
1. Enter additional arguments.
    <img width="1498" alt=" 2025-05-07 at 23 42 37" src="https://github.com/user-attachments/assets/e3760e01-fd83-40ba-9e9c-ac5eeccf73fb" />
1. Press `Enter` to execute the command.
    <img width="1498" alt=" 2025-05-07 at 23 42 48" src="https://github.com/user-attachments/assets/da95f25f-ffc3-43e0-99a5-541715352c69" />
1. The command is executed with the additional arguments.
	<img width="1498" alt=" 2025-05-07 at 23 46 42" src="https://github.com/user-attachments/assets/81345ff0-4cf7-4e97-821c-307e6bc4b33b" />

## TODO
- [x] Implementation
	- [x] UI
	- [x] Internal logic
- [x] Test
- [x] Documentation
	- [x] Update README if need
	- [x] Update keybindings pane
- [x] Write up PR body
	- [x] Put screenshot for this feature
- [ ] (After release) Tell the person requested this feature on reddit releasing this feature.

<details><summary>Test</summary>
<p>

- [x] document these test cases in `/docs/MANUAL_TEST_CASES.md`.
- [x] `fzf-make`
    - [x] Execution
        - [x] A command name executing is shown
        - [x] Selected command is executed
    - [x] Narrowing down
        - [x] Placeholder is shown when no characters are typed.
        - [x] Narrowing down works properly when some characters are typed.
        - [x] No command is shown when no command is matched.
        - [x] Focus is reset when backspace is pressed.
        - [x] Focus is reset when a character is typed.
    - [x] Preview window
        - [x] Preview window works properly.
    - [x] History
        - [x] A executed command is stored in histories after execution
        - [x] Histories is shown properly
        - [x] Any command can be executed from history pane
    - [x] Quitting
        - [x] `esc` quits fzf-make
    - [x] Additional arguments popup
        - [x] common
            - [x] `esc` closes the popup
        - [x] make
            - [x] no additional argument
                - [x] can be executed properly
                - [x] can be saved properly
            - [x] one additional arguments
                - [x] can be executed properly
                - [x] can be saved properly
            - [x] multiple additional arguments
                - [x] can be executed properly
                - [x] can be saved properly
        - [x] pnpm
            - [x] no additional argument
                - [x] can be executed properly
                - [x] can be saved properly
            - [x] one additional arguments
                - [x] can be executed properly
                - [x] can be saved properly
            - [x] multiple additional arguments
                - [x] can be executed properly
                - [x] can be saved properly
        - [x] yarn
            - [x] no additional argument
                - [x] can be executed properly
                - [x] can be saved properly
            - [x] one additional arguments
                - [x] can be executed properly
                - [x] can be saved properly
            - [x] multiple additional arguments
                - [x] can be executed properly
                - [x] can be saved properly
        - [x] just
            - [x] no additional argument
                - [x] can be executed properly
                - [x] can be saved properly
            - [x] one additional arguments
                - [x] can be executed properly
                - [x] can be saved properly
            - [x] multiple additional arguments
                - [x] can be executed properly
                - [x] can be saved properly
- [x] `fzf-make --repeat` executes the command the last one.
- [x] `fzf-make --history` launches fzf-make focusing history pane.


</p>
</details> 
