### PR TITLE
fix(ui): fix key blocking #467

### DIFF
--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -280,9 +280,13 @@ enum Message {
 
 // TODO: make this method Model's method
 fn handle_event(model: &Model) -> io::Result<Option<Message>> {
-    match (crossterm::event::poll(std::time::Duration::from_millis(10000))?, crossterm::event::read()?) {
-        (true, crossterm::event::Event::Key(key)) => Ok(model.handle_key_input(key)),
-        _ => Ok(None),
+    if crossterm::event::poll(std::time::Duration::from_millis(500))? {
+        match crossterm::event::read()? {
+            crossterm::event::Event::Key(key) => Ok(model.handle_key_input(key)),
+            _ => Ok(None),
+        }
+    } else {
+        Ok(None)
     }
 }
 


### PR DESCRIPTION
#467

According to claude, original implementation has a problem.
Since this is my hobby project, so I won't conduct a detailed investigation now that I've confirmed the problem has been actually solved.


Following content is from claude sonnet 3.7.

# Fix Event Handling in Terminal UI

## Problem

The current implementation of the event handling function has an issue where key inputs can be missed after a timeout occurs. This happens because of how the `poll` and `read` functions are evaluated together in a tuple pattern match.

```rust
fn handle_event(model: &Model) -> io::Result<Option<Message>> {
    match (crossterm::event::poll(std::time::Duration::from_millis(10000))?, crossterm::event::read()?) {
        (true, crossterm::event::Event::Key(key)) => Ok(model.handle_key_input(key)),
        _ => Ok(None),
    }
}
```

### Technical explanation

The issue occurs because:

1. When `poll` times out after 10000ms, it returns `false`
2. The `read()` function then executes, but since it's a blocking call, it waits for the next input
3. When a user presses a key after the timeout, `read()` captures this event
4. However, this creates a tuple of `(false, Event::Key(...))` which doesn't match the pattern `(true, Event::Key(key))`
5. As a result, the key input is detected but not processed (it falls into the `_ => Ok(None)` case)

This creates a situation where the first key press after a timeout is effectively ignored, requiring users to press keys twice to get a response.

## Solution

This PR refactors the event handling to properly separate the poll and read operations:

```rust
fn handle_event(model: &Model) -> io::Result<Option<Message>> {
    if crossterm::event::poll(std::time::Duration::from_millis(10000))? {
        // Only call read() when poll() indicates an event is available
        match crossterm::event::read()? {
            crossterm::event::Event::Key(key) => Ok(model.handle_key_input(key)),
            _ => Ok(None)
        }
    } else {
        // Timeout case
        Ok(None)
    }
}
```

This implementation:
- First checks if an event is available using `poll()`
- Only calls the blocking `read()` function when `poll()` indicates an event is ready
- Properly handles the timeout case separately

With this approach, no key inputs will be missed after a timeout, improving the responsiveness and reliability of the UI.