### PR TITLE
chore(git): ignore html files for repository language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/*.html linguist-vendored=true


### PR DESCRIPTION
Fix this.
<img width="463" alt=" 2025-05-11 at 1 55 27" src="https://github.com/user-attachments/assets/a7edf4d8-27e3-4c96-b4a0-6017162cc996" />
