### PR TITLE
chore(ci): add retry mechanism to checking license file workflow

### DIFF
--- a/.github/workflows/check-license-file.yml
+++ b/.github/workflows/check-license-file.yml
@@ -10,8 +10,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Check
-        run: make update-license-file
+      
+      - name: Check and update license file with retry
+        run: |
+          for i in {1..3}; do
+            echo "Attempt $i"
+            if make update-license-file; then
+              echo "Success on attempt $i"
+              break
+            else
+              if [ $i -eq 3 ]; then
+                echo "Failed after 3 attempts"
+                exit 1
+              fi
+              echo "Failed attempt $i, retrying..."
+              sleep 2
+            fi
+          done
+      
       - name: Check diff
         run: |
           git add .


### PR DESCRIPTION
This workflow sometimes fails, and retrying resolves it.