### PR TITLE
feature: support quit with ctrl-c

### DIFF
--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -84,7 +84,7 @@ impl Model<'_> {
                 match s.current_pane {
                     CurrentPane::Main => match (key.code, is_ctrl_pressed) {
                         (KeyCode::Tab, _) => Some(Message::MoveToNextPane),
-                        (KeyCode::Esc, _) => Some(Message::Quit),
+                        (KeyCode::Esc, _) | (KeyCode::Char('c'), true) => Some(Message::Quit),
                         (KeyCode::Down, _) | (KeyCode::Char('n'), true) => Some(Message::NextCommand),
                         (KeyCode::Up, _) | (KeyCode::Char('p'), true) => Some(Message::PreviousCommand),
                         (KeyCode::Char('o'), true) => Some(Message::OpenAdditionalArgumentsWindow),
@@ -93,8 +93,7 @@ impl Model<'_> {
                     },
                     CurrentPane::History => match (key.code, is_ctrl_pressed) {
                         (KeyCode::Tab, _) => Some(Message::MoveToNextPane),
-                        (KeyCode::Esc, _) => Some(Message::Quit),
-                        (KeyCode::Char('q'), _) => Some(Message::Quit),
+                        (KeyCode::Esc, _) | (KeyCode::Char('c'), true) | (KeyCode::Char('q'), _) => Some(Message::Quit),
                         (KeyCode::Down, _) | (KeyCode::Char('n'), true) => Some(Message::NextHistory),
                         (KeyCode::Up, _) | (KeyCode::Char('p'), true) => Some(Message::PreviousHistory),
                         (KeyCode::Char('o'), true) => Some(Message::OpenAdditionalArgumentsWindow),

--- a/src/usecase/tui/ui.rs
+++ b/src/usecase/tui/ui.rs
@@ -343,10 +343,10 @@ fn render_hint_block(model: &mut SelectCommandState, f: &mut Frame, chunk: ratat
     } else {
         match model.current_pane {
             CurrentPane::Main => {
-                "Execute the selected command: <enter> | Select command: ↑/↓ | Narrow down command: (type any character) | Move to next tab: <tab> | Quit: <esc>"
+                "Execute the selected command: <enter> | Select command: ↑/↓ | Narrow down command: (type any character) | Move to next tab: <tab> | Quit: <c-c>/<esc>"
             }
             CurrentPane::History => {
-                "Execute the selected command: <enter> | Select command: ↑/↓ | Move to next tab: <tab> | Quit: q/<esc>"
+                "Execute the selected command: <enter> | Select command: ↑/↓ | Move to next tab: <tab> | Quit: <c-c>/q/<esc>"
             }
         }
     };


### PR DESCRIPTION
## What
<!-- Please describe what you have done in this pull request. -->
Added signal handling to properly respond to Ctrl+C (SIGINT). The application now gracefully terminates when the user presses Ctrl+C, which is the standard expected behavior for terminal applications.

## Why
<!--
    Please describe what is the motivation for this PR.
    If there is an related issue, it's fine to just write the issue number if it describes the motivation of this PR well.
-->

Currently, the application does not respond to Ctrl+C, which violates standard Unix/terminal conventions and creates a poor user experience. Users expect Ctrl+C to interrupt and exit a running terminal application. This PR ensures the application behaves like other well-designed CLI tools and respects standard terminal signal handling.


## Testing
<!-- Please describe what you have done to test this PR. -->

I tested that ctrl-c terminates in both the execution & history mode.

## TODO
<!-- Please check the items below before submitting a PR. -->
- [x] I have read and followed the guidelines in [`CONTRIBUTING.md`](https://github.com/kyu08/fzf-make/blob/main/CONTRIBUTING.md).
- [x] I have double-checked my code for mistakes.
- [x] I have added comments to help maintainers understand my code if needed.
