### PR TITLE
fix(ui): hide the preview window when height is below a certain threshold

### DIFF
--- a/src/usecase/tui/ui.rs
+++ b/src/usecase/tui/ui.rs
@@ -80,7 +80,7 @@ pub fn ui(f: &mut Frame, model: &mut Model) {
     }
 }
 
-const HEIGHT_THRESHOLD_TO_HIDE_PREVIEW_WINDOW: u16 = 25;
+const HEIGHT_THRESHOLD_TO_HIDE_PREVIEW_WINDOW: u16 = 20;
 const FG_COLOR_SELECTED: ratatui::style::Color = Color::Rgb(161, 220, 156);
 const FG_COLOR_NOT_SELECTED: ratatui::style::Color = Color::DarkGray;
 const BORDER_STYLE_SELECTED: ratatui::widgets::block::BorderType = ratatui::widgets::BorderType::Thick;


### PR DESCRIPTION
Resolves #547 

| The window height < 20 | The window height >= 20 |
|---|---|
|<img width="1994" height="634" alt="CleanShot 2025-10-13 at 15 50 55@2x" src="https://github.com/user-attachments/assets/9fba6325-a0a6-4c87-9e6e-70fb611bc507" />|<img width="1994" height="704" alt="CleanShot 2025-10-13 at 15 50 42@2x" src="https://github.com/user-attachments/assets/096a7a2b-930c-4d27-8bb8-cc6daf597d21" />|

