### PR TITLE
chore(cd): add github release workflow for pre-built Linux binaries

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,4 +1,4 @@
-name: Github Release
+name: GitHub Release
 
 on:
   push:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,47 @@
+name: Github Release
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/create-gh-release-action@v1
+
+  upload-assets:
+    needs: create-release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+            archive: fzf-make_$tag_linux_arm64
+            os: ubuntu-latest
+          - target: x86_64-unknown-linux-gnu
+            archive: fzf-make_$tag_linux_amd64
+            os: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: fzf-make
+          target: ${{ matrix.target }}
+          archive: ${{ matrix.archive }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: taiki-e/create-gh-release-action@v1
+      - uses: taiki-e/create-gh-release-action@eba8ea96c86cca8a37f1b56e94b4d13301fba651 # v1.11.0
 
   upload-assets:
     needs: create-release
@@ -39,7 +39,7 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: taiki-e/upload-rust-binary-action@v1
+      - uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1.30.2
         with:
           bin: fzf-make
           target: ${{ matrix.target }}

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,9 +1,12 @@
 name: GitHub Release
 
 on:
-  push:
-    tags:
-      - "*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v0.69.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -15,17 +18,22 @@ jobs:
       matrix:
         include:
           - target: aarch64-unknown-linux-gnu
-            archive: fzf-make_$tag_linux_arm64
+            archive: fzf-make_${{ inputs.tag }}_linux_arm64
             os: ubuntu-latest
           - target: x86_64-unknown-linux-gnu
-            archive: fzf-make_$tag_linux_amd64
+            archive: fzf-make_${{ inputs.tag }}_linux_amd64
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: main
+      - name: Create local tag for build context
+        run: git tag "${{ inputs.tag }}"
       - uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1.30.2
         with:
           bin: fzf-make
           target: ${{ matrix.target }}
           archive: ${{ matrix.archive }}
+          ref: refs/tags/${{ inputs.tag }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -12,7 +12,7 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: taiki-e/create-gh-release-action@eba8ea96c86cca8a37f1b56e94b4d13301fba651 # v1.11.0
 
   upload-assets:
@@ -29,7 +29,7 @@ jobs:
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1.30.2
         with:
           bin: fzf-make

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -30,15 +30,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1.30.2
         with:
           bin: fzf-make

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -9,14 +9,7 @@ permissions:
   contents: write
 
 jobs:
-  create-release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: taiki-e/create-gh-release-action@eba8ea96c86cca8a37f1b56e94b4d13301fba651 # v1.11.0
-
   upload-assets:
-    needs: create-release
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -27,9 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: main
-      - name: Create local tag for build context
-        run: git tag "${{ inputs.tag }}"
+          ref: refs/tags/${{ inputs.tag }}
       - uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1.30.2
         with:
           bin: fzf-make

--- a/Makefile
+++ b/Makefile
@@ -73,11 +73,23 @@ bump-fzf-make-version: tool-bump-version
 		git pull; \
 		cargo set-version --bump minor; \
 		export CURRENT_VERSION=$$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version'); \
+		export RELEASE_BRANCH="release/v$${CURRENT_VERSION}"; \
 		make update-license-file; \
+		git checkout -b "$${RELEASE_BRANCH}"; \
 		git add .; \
 		git commit -m "chore(release): bump to v$${CURRENT_VERSION}"; \
-		git push origin HEAD; \
-		gh release create "v$${CURRENT_VERSION}" --generate-notes --draft | sed 's@releases/tag@releases/edit@' | xargs open; \
+		git push -u origin "$${RELEASE_BRANCH}"; \
+		gh pr create --base main --head "$${RELEASE_BRANCH}" \
+			--title "chore(release): bump to v$${CURRENT_VERSION}" \
+			--body "Automated bump for v$${CURRENT_VERSION}."; \
+		gh pr merge "$${RELEASE_BRANCH}" --squash --auto --delete-branch; \
+		echo "⏳ Waiting for PR to be merged..."; \
+		while [ "$$(gh pr view $${RELEASE_BRANCH} --json state -q .state 2>/dev/null)" != "MERGED" ]; do sleep 3; done; \
+		git checkout main; \
+		git pull; \
+		gh release create "v$${CURRENT_VERSION}" --generate-notes --draft --target main; \
+		gh workflow run github-release.yml -f tag="v$${CURRENT_VERSION}"; \
+		gh release view "v$${CURRENT_VERSION}" --json url -q .url | sed 's@releases/tag@releases/edit@' | xargs open; \
 	fi
 
 .PHONY: spell-check

--- a/Makefile
+++ b/Makefile
@@ -79,16 +79,21 @@ bump-fzf-make-version: tool-bump-version
 		git add .; \
 		git commit -m "chore(release): bump to v$${CURRENT_VERSION}"; \
 		git push -u origin "$${RELEASE_BRANCH}"; \
-		gh pr create --base main --head "$${RELEASE_BRANCH}" \
+		PR_URL=$$(gh pr create --base main --head "$${RELEASE_BRANCH}" \
 			--title "chore(release): bump to v$${CURRENT_VERSION}" \
-			--body "Automated bump for v$${CURRENT_VERSION}."; \
-		gh pr merge "$${RELEASE_BRANCH}" --squash --auto --delete-branch; \
-		echo "⏳ Waiting for PR to be merged..."; \
-		while [ "$$(gh pr view $${RELEASE_BRANCH} --json state -q .state 2>/dev/null)" != "MERGED" ]; do sleep 3; done; \
+			--body "Automated bump for v$${CURRENT_VERSION}."); \
+		PR_NUMBER=$$(basename "$$PR_URL"); \
+		gh pr merge "$$PR_NUMBER" --squash --auto --delete-branch; \
+		echo "⏳ Waiting for PR #$$PR_NUMBER to be merged..."; \
+		while :; do STATE=$$(gh pr view "$$PR_NUMBER" --json state -q .state 2>/dev/null); case "$$STATE" in MERGED) break ;; CLOSED) echo "❌ PR #$$PR_NUMBER was closed without merging. Aborting."; exit 1 ;; esac; sleep 3; done; \
 		git checkout main; \
 		git pull; \
 		gh release create "v$${CURRENT_VERSION}" --generate-notes --draft --target main; \
 		gh workflow run github-release.yml -f tag="v$${CURRENT_VERSION}"; \
+		echo "⏳ Waiting for the release workflow to finish..."; \
+		sleep 5; \
+		RUN_ID=$$(gh run list --workflow=github-release.yml --event=workflow_dispatch --limit 1 --json databaseId -q '.[0].databaseId'); \
+		gh run watch "$$RUN_ID" --exit-status || echo "❌ Release workflow failed. Check: https://github.com/kyu08/fzf-make/actions/runs/$$RUN_ID"; \
 		gh release view "v$${CURRENT_VERSION}" --json url -q .url | sed 's@releases/tag@releases/edit@' | xargs open; \
 	fi
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ cargo +1.90.0 install --locked fzf-make
 cargo +1.90.0 install --git https://github.com/kyu08/fzf-make/
 ```
 
-## Pre-build binary for Linux
+## Pre-built binaries for Linux
 Pre-built binaries are available for `linux_amd64` and `linux_arm64`.
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -69,12 +69,27 @@ nix run nixpkgs#fzf-make
 > You may need to enable experimental feature. In that case, execute the following command to enable them
 > `echo "experimental-features = nix-command flakes" | tee  ~/.config/nix/nix.conf`
 
-## OS-independent method
-### Cargo
+## Cargo
 ```sh
 cargo +1.90.0 install --locked fzf-make
 # Or build from the latest source
 cargo +1.90.0 install --git https://github.com/kyu08/fzf-make/
+```
+
+## Pre-build binary for Linux
+Pre-built binaries are available for `linux_amd64` and `linux_arm64`.
+
+> [!NOTE]
+> Replace `/usr/local/bin` with any directory in your `$PATH` if you prefer another installation place.
+
+### linux_amd64
+```sh
+TAG=$(curl -fsSL https://api.github.com/repos/kyu08/fzf-make/releases/latest | grep -m1 tag_name | cut -d '"' -f 4) && curl -fsSL "https://github.com/kyu08/fzf-make/releases/download/${TAG}/fzf-make_${TAG}_linux_amd64.tar.gz" | tar -xz && sudo mv fzf-make /usr/local/bin/
+```
+
+### linux_arm64
+```sh
+TAG=$(curl -fsSL https://api.github.com/repos/kyu08/fzf-make/releases/latest | grep -m1 tag_name | cut -d '"' -f 4) && curl -fsSL "https://github.com/kyu08/fzf-make/releases/download/${TAG}/fzf-make_${TAG}_linux_arm64.tar.gz" | tar -xz && sudo mv fzf-make /usr/local/bin/
 ```
 
 # 💡 Usage


### PR DESCRIPTION
## What
I noticed that `fzf-make` does not have any binaries for linux (which I needed) and have to install rust to build from source. This PR generates a binaries for arm64 and amd64 devices whenever a tag is created.

## Why
`fzf-make` is a great tool and I found it difficult to use the same in multiple of devices because I have to build from source each time.

Partially closes #377 due to one of its comments asking for pre-built binaries

## Workflow
The workflow is pretty simple. It auto creates a release (via taiki-e/create-gh-release-action) and uploads the binaries when its completed (via taiki-e/upload-rust-binary-action).

## Pre-submission Checklist

- [x] I have read and followed the guidelines in [`CONTRIBUTING.md`](https://github.com/kyu08/fzf-make/blob/main/CONTRIBUTING.md).
- [x] I have double-checked my code for mistakes.
- [x] I have added comments to help maintainers understand my code if needed.

## Additional Info

This work flow could be extended to macOS and windows as well but did not include because macOS users can use brew and I didn't see any issues related windows.