### PR TITLE
fix(cd): checkout default branch instead of non-existent tag

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -26,8 +26,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: refs/tags/${{ inputs.tag }}
       - uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1.30.2
         with:
           bin: fzf-make


### PR DESCRIPTION
The GitHub Release workflow tried to checkout refs/tags/${tag} which does not exist when the release is still a draft, causing the job to fail with exit code 128. Drop the explicit ref so checkout uses the workflow's default branch (the commit the workflow was dispatched from).
