### PR TITLE
fix(cd): pin brew-release action to fork to work around HTTP 303 bug

### DIFF
--- a/.github/workflows/brew-release.yml
+++ b/.github/workflows/brew-release.yml
@@ -7,7 +7,10 @@ jobs:
   bump-homebrew-formula:
     runs-on: ubuntu-latest
     steps:
-      - uses: mislav/bump-homebrew-formula-action@56a283fa15557e9abaa4bdb63b8212abc68e655c # v3.6
+      # Pinned to a fork that fixes https://github.com/mislav/bump-homebrew-formula-action/issues/340
+      # (GitHub now returns HTTP 303 instead of 302 for tarball redirects, which upstream rejects).
+      # Revert to mislav/bump-homebrew-formula-action once the upstream fix is released.
+      - uses: AvesAlight/bump-homebrew-formula-action@efacc598ed9b4b1bc526125f82d2dfba17509842
         if: ${{ !contains(github.ref, '-') }} # skip prereleases
         with:
           formula-name: fzf-make


### PR DESCRIPTION
## Summary

- The v0.69.0 Brew Release [workflow run](https://github.com/kyu08/fzf-make/actions/runs/25982426480/job/76373426666) failed with `Error: unexpected HTTP 303 response`.
- Root cause: `mislav/bump-homebrew-formula-action`'s `resolveRedirect` only accepts `res.statusCode == 302`, but GitHub's tarball API now returns HTTP 303. Tracked upstream as [mislav/bump-homebrew-formula-action#340](https://github.com/mislav/bump-homebrew-formula-action/issues/340); not fixed in the latest v4.1 either.
- Pin `uses:` to [`AvesAlight/bump-homebrew-formula-action@efacc59`](https://github.com/AvesAlight/bump-homebrew-formula-action/commit/efacc598ed9b4b1bc526125f82d2dfba17509842), a fork that widens the check to any 3xx with a `Location` header (mirrors the existing `stream()` helper in the same file).

## Follow-up

- Revert to `mislav/bump-homebrew-formula-action` (tagged release) once the upstream fix is released.

## Test plan

- [ ] CI passes on this PR
- [ ] On the next `v*` tag push, the Brew Release workflow completes successfully