### PR TITLE
fix(file_util): handle file related errors properly

### DIFF
--- a/src/model/file_util.rs
+++ b/src/model/file_util.rs
@@ -50,3 +50,63 @@ pub fn write_debug_info_to_file(content: &str) -> std::io::Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use std::fs::{self, File};
+    use uuid::Uuid;
+
+    #[test]
+    fn find_file_in_ancestors_finds_file_in_ancestor() {
+        // Layout:
+        //   <tmp_root>/justfile
+        //   <tmp_root>/child/grandchild   <- start searching from here
+        let tmp_root = std::env::temp_dir().join(Uuid::new_v4().to_string());
+        let start_dir = tmp_root.join("child").join("grandchild");
+        fs::create_dir_all(&start_dir).unwrap();
+        File::create(tmp_root.join("justfile")).unwrap();
+
+        let result = find_file_in_ancestors(start_dir, vec!["justfile", ".justfile"]);
+
+        assert_eq!(result, Some(tmp_root.join("justfile")));
+
+        fs::remove_dir_all(&tmp_root).unwrap();
+    }
+
+    // Regression test for the Homebrew Linux C crash where `read_dir` returned
+    // PermissionDenied on an ancestor directory and the function panicked.
+    // https://github.com/Homebrew/homebrew-core/pull/295008#issuecomment-5071286646
+    //
+    // A directory with mode 0o111 (execute-only) can be traversed but not read,
+    // so `read_dir` fails with PermissionDenied for it. The function must skip
+    // such directories and keep searching readable ancestors instead of panicking.
+    #[cfg(unix)]
+    #[test]
+    fn find_file_in_ancestors_skips_unreadable_ancestor() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Layout:
+        //   <tmp_root>/justfile
+        //   <tmp_root>/unreadable          <- mode 0o111: traversable but not readable
+        //   <tmp_root>/unreadable/leaf     <- start searching from here
+        let tmp_root = std::env::temp_dir().join(Uuid::new_v4().to_string());
+        let unreadable = tmp_root.join("unreadable");
+        let start_dir = unreadable.join("leaf");
+        fs::create_dir_all(&start_dir).unwrap();
+        File::create(tmp_root.join("justfile")).unwrap();
+
+        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o111)).unwrap();
+
+        // Must not panic on the unreadable ancestor, and must still find the file
+        // in the readable ancestor above it.
+        let result = find_file_in_ancestors(start_dir, vec!["justfile", ".justfile"]);
+
+        assert_eq!(result, Some(tmp_root.join("justfile")));
+
+        // Restore read permission so the cleanup can recurse into the directory.
+        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o755)).unwrap();
+        fs::remove_dir_all(&tmp_root).unwrap();
+    }
+}

--- a/src/model/file_util.rs
+++ b/src/model/file_util.rs
@@ -11,8 +11,16 @@ pub fn path_to_content(path: PathBuf) -> Result<String> {
 
 pub fn find_file_in_ancestors(current_dir: PathBuf, file_names: Vec<&str>) -> Option<PathBuf> {
     for path in current_dir.ancestors() {
-        for entry in PathBuf::from(path).read_dir().unwrap() {
-            let entry = entry.unwrap();
+        let read_dir = match PathBuf::from(path).read_dir() {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+
+        for entry in read_dir {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
             let file_name = entry.file_name().to_string_lossy().to_lowercase();
             if file_names.contains(&file_name.as_str()) {
                 return Some(entry.path());

--- a/src/model/file_util.rs
+++ b/src/model/file_util.rs
@@ -11,7 +11,7 @@ pub fn path_to_content(path: PathBuf) -> Result<String> {
 
 pub fn find_file_in_ancestors(current_dir: PathBuf, file_names: Vec<&str>) -> Option<PathBuf> {
     for path in current_dir.ancestors() {
-        let read_dir = match PathBuf::from(path).read_dir() {
+        let read_dir = match path.read_dir() {
             Ok(r) => r,
             Err(_) => continue,
         };


### PR DESCRIPTION
## What
<!-- Please describe what you have done in this pull request. -->
SSIA

## Why
To fix this CI error https://github.com/Homebrew/homebrew-core/pull/295008#issuecomment-5071286646.
<!--
    Please describe what is the motivation for this PR.
    If there is an related issue, it's fine to just write the issue number if it describes the motivation of this PR well.
-->

```
==> /home/linuxbrew/.linuxbrew/Cellar/fzf-make/0.71.0/bin/fzf-make -v
Error: fzf-make: failed
An exception occurred within a child process:
Minitest::Assertion: Expected /make\ brew/ to match "\e[?1049h\e[?1000h\e[?1002h\e[?1003h\e[?1015h\e[?1006hthread 'main' panicked at src/model/file_util.rs:14:53\ncalled ``Result::unwrap()`` on an ``Err`` value: Os { code: 13, kind: PermissionDenied, message: \"Permission denied\" }\n\e[?1049l\e[?1006l\e[?1015l\e[?1003l\e[?1002l\e[?1000l\e[?25hthread 'main' panicked at src/model/file_util.rs:14:53\ncalled ``Result::unwrap()`` on an ``Err`` value: Os { code: 13, kind: PermissionDenied, message: \"Permission denied\" }\n".
```


