### PR TITLE
chore(check_new_version): change check interval to 1 hour from 24 hours

### DIFF
--- a/src/usecase/tui/app.rs
+++ b/src/usecase/tui/app.rs
@@ -270,9 +270,8 @@ fn shutdown_terminal(terminal: &mut Terminal<CrosstermBackend<Stderr>>) -> Resul
 const PKG_NAME: &str = "kyu08/fzf-make";
 async fn get_latest_version(share_clone: Arc<Mutex<HashMap<String, String>>>) {
     let current_version = env!("CARGO_PKG_VERSION").to_string();
-    // check version once a day
-    let informer =
-        update_informer::new(registry::GitHub, PKG_NAME, current_version).interval(Duration::from_secs(60 * 60 * 24));
+    let check_interval = Duration::from_secs(60 * 60); // 1 hour
+    let informer = update_informer::new(registry::GitHub, PKG_NAME, current_version).interval(check_interval);
 
     let version_result = task::spawn_blocking(|| informer.check_version().map_err(|e| e.to_string()))
         .await


### PR DESCRIPTION
closes #615

## What
SSIA
<!-- Please describe what you have done in this pull request. -->

## Why
Because a shorter check interval makes it convenient to catch new releases quickly, and an interval this short shouldn't cause any performance issues either.
<!--
    Please describe what is the motivation for this PR.
    If there is an related issue, it's fine to just write the issue number if it describes the motivation of this PR well.
-->
